### PR TITLE
Use Celery delay for OpenNebula tasks and fix VM wizard

### DIFF
--- a/src/waldur_opennebula/client.py
+++ b/src/waldur_opennebula/client.py
@@ -1,18 +1,30 @@
-import pyone
 import logging
+
+import pyone
+
 from .exceptions import OpenNebulaError
 
 logger = logging.getLogger(__name__)
 
 
 def _to_template_str(data_dict):
-    return '\n'.join([f'{key.upper()}="{value}"' if isinstance(value, str) else f'{key.upper()}={value}' for key, value in data_dict.items()])
+    return "\n".join(
+        [
+            f'{key.upper()}="{value}"'
+            if isinstance(value, str)
+            else f"{key.upper()}={value}"
+            for key, value in data_dict.items()
+        ]
+    )
 
 
 class OpenNebulaClient:
     def __init__(self, settings):
-        self.one = pyone.OneServer(settings.backend_url, session="%s:%s" % (settings.username, settings.password))
-        
+        self.one = pyone.OneServer(
+            settings.backend_url,
+            session=f"{settings.username}:{settings.password}",
+        )
+
     def get_version(self):
         """
         Returns the OpenNebula system version.
@@ -22,7 +34,7 @@ class OpenNebulaClient:
         try:
             return self.one.system.version()
         except pyone.OneException as e:
-            logger.exception('Failed to get OpenNebula version')
+            logger.exception("Failed to get OpenNebula version")
             raise OpenNebulaError(e)
 
     def list_vms(self):
@@ -34,7 +46,7 @@ class OpenNebulaClient:
         try:
             return self.one.vmpool.info(-2, -1, -1, -1, -1)
         except pyone.OneException as e:
-            logger.exception('Failed to list VMs')
+            logger.exception("Failed to list VMs")
             raise OpenNebulaError(e)
 
     def get_vm(self, vm_id):
@@ -48,7 +60,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.info(vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get VM info')
+            logger.exception("Failed to get VM info")
             raise OpenNebulaError(e)
 
     def create_vm(self, template_id, name=None, extra=None):
@@ -67,11 +79,13 @@ class OpenNebulaClient:
             template_modifications = ""
             if extra:
                 template_modifications = _to_template_str(extra)
-            # template.instantiate is suitable for creating a VM from a template ID 
+            # template.instantiate is suitable for creating a VM from a template ID
             # and applying modifications like CPU, MEMORY.
-            return self.one.template.instantiate(int(template_id), name, False, template_modifications)
+            return self.one.template.instantiate(
+                int(template_id), name, False, template_modifications
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to create VM by instantiating template')
+            logger.exception("Failed to create VM by instantiating template")
             raise OpenNebulaError(e)
 
     def delete_vm(self, vm_id):
@@ -83,9 +97,9 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.action('delete', vm_id)
+            return self.one.vm.action("delete", vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete VM')
+            logger.exception("Failed to delete VM")
             raise OpenNebulaError(e)
 
     def start_vm(self, vm_id):
@@ -97,9 +111,9 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.action('resume', vm_id)
+            return self.one.vm.action("resume", vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to start VM')
+            logger.exception("Failed to start VM")
             raise OpenNebulaError(e)
 
     def stop_vm(self, vm_id):
@@ -111,9 +125,9 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.action('poweroff', vm_id)
+            return self.one.vm.action("poweroff", vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to stop VM')
+            logger.exception("Failed to stop VM")
             raise OpenNebulaError(e)
 
     def reboot_vm(self, vm_id):
@@ -125,9 +139,9 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.action('reboot', vm_id)
+            return self.one.vm.action("reboot", vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to reboot VM')
+            logger.exception("Failed to reboot VM")
             raise OpenNebulaError(e)
 
     def resize_vm(self, vm_id, cpu=None, ram=None):
@@ -148,17 +162,19 @@ class OpenNebulaClient:
                 template_parts.append(f"CPU={cpu}")
             if ram is not None:
                 template_parts.append(f"MEMORY={ram}")
-            
+
             if not template_parts:
-                logger.warning(f"Resize VM ({vm_id}) called without CPU or RAM changes.")
-                return True # No changes to apply
+                logger.warning(
+                    f"Resize VM ({vm_id}) called without CPU or RAM changes."
+                )
+                return True  # No changes to apply
 
             template_str = "\n".join(template_parts)
-            # Using mode 0 to merge/update existing attributes. 
+            # Using mode 0 to merge/update existing attributes.
             # Mode 1 would replace the whole template.
-            return self.one.vm.update(vm_id, template_str, 0)  
+            return self.one.vm.update(vm_id, template_str, 0)
         except pyone.OneException as e:
-            logger.exception('Failed to resize VM')
+            logger.exception("Failed to resize VM")
             raise OpenNebulaError(e)
 
     def attach_disk(self, vm_id, disk_template):
@@ -174,7 +190,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.attach(vm_id, _to_template_str(disk_template))
         except pyone.OneException as e:
-            logger.exception('Failed to attach disk to VM')
+            logger.exception("Failed to attach disk to VM")
             raise OpenNebulaError(e)
 
     def detach_disk(self, vm_id, disk_id):
@@ -190,7 +206,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.detach(vm_id, disk_id)
         except pyone.OneException as e:
-            logger.exception('Failed to detach disk from VM')
+            logger.exception("Failed to detach disk from VM")
             raise OpenNebulaError(e)
 
     def snapshot_vm(self, vm_id, name):
@@ -206,7 +222,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.snapshot_create(vm_id, name)
         except pyone.OneException as e:
-            logger.exception('Failed to create VM snapshot')
+            logger.exception("Failed to create VM snapshot")
             raise OpenNebulaError(e)
 
     def restore_vm_snapshot(self, vm_id, snapshot_id):
@@ -222,7 +238,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.snapshot_revert(vm_id, snapshot_id)
         except pyone.OneException as e:
-            logger.exception('Failed to restore VM snapshot')
+            logger.exception("Failed to restore VM snapshot")
             raise OpenNebulaError(e)
 
     def get_console(self, vm_id):
@@ -236,7 +252,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.console(vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get VM console info')
+            logger.exception("Failed to get VM console info")
             raise OpenNebulaError(e)
 
     # Tenant (group/project) management
@@ -249,7 +265,7 @@ class OpenNebulaClient:
         try:
             return self.one.grouppool.info()
         except pyone.OneException as e:
-            logger.exception('Failed to list groups')
+            logger.exception("Failed to list groups")
             raise OpenNebulaError(e)
 
     def get_group(self, group_id):
@@ -263,7 +279,7 @@ class OpenNebulaClient:
         try:
             return self.one.group.info(group_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get group info')
+            logger.exception("Failed to get group info")
             raise OpenNebulaError(e)
 
     def create_group(self, name, description=None):
@@ -277,12 +293,12 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            params = {'NAME': name}
+            params = {"NAME": name}
             if description:
-                params['DESCRIPTION'] = description
+                params["DESCRIPTION"] = description
             return self.one.group.allocate(params)
         except pyone.OneException as e:
-            logger.exception('Failed to create group')
+            logger.exception("Failed to create group")
             raise OpenNebulaError(e)
 
     def delete_group(self, group_id):
@@ -296,7 +312,7 @@ class OpenNebulaClient:
         try:
             return self.one.group.delete(group_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete group')
+            logger.exception("Failed to delete group")
             raise OpenNebulaError(e)
 
     def list_networks(self):
@@ -308,7 +324,7 @@ class OpenNebulaClient:
         try:
             return self.one.vnpool.info()
         except pyone.OneException as e:
-            logger.exception('Failed to list networks')
+            logger.exception("Failed to list networks")
             raise OpenNebulaError(e)
 
     def get_network(self, network_id):
@@ -322,7 +338,7 @@ class OpenNebulaClient:
         try:
             return self.one.vn.info(network_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get network info')
+            logger.exception("Failed to get network info")
             raise OpenNebulaError(e)
 
     def create_network(self, name, description=None):
@@ -336,12 +352,12 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            params = {'NAME': name}
+            params = {"NAME": name}
             if description:
-                params['DESCRIPTION'] = description
+                params["DESCRIPTION"] = description
             return self.one.vn.allocate(params)
         except pyone.OneException as e:
-            logger.exception('Failed to create network')
+            logger.exception("Failed to create network")
             raise OpenNebulaError(e)
 
     def delete_network(self, network_id):
@@ -355,7 +371,7 @@ class OpenNebulaClient:
         try:
             return self.one.vn.delete(network_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete network')
+            logger.exception("Failed to delete network")
             raise OpenNebulaError(e)
 
     def list_volumes(self):
@@ -367,7 +383,7 @@ class OpenNebulaClient:
         try:
             return self.one.imagepool.info(-2, -1, -1, -1)
         except pyone.OneException as e:
-            logger.exception('Failed to list volumes')
+            logger.exception("Failed to list volumes")
             raise OpenNebulaError(e)
 
     def get_volume(self, volume_id):
@@ -381,7 +397,7 @@ class OpenNebulaClient:
         try:
             return self.one.image.info(volume_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get volume info')
+            logger.exception("Failed to get volume info")
             raise OpenNebulaError(e)
 
     def create_volume(self, name, size, description=None):
@@ -397,12 +413,12 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            params = {'NAME': name, 'SIZE': size}
+            params = {"NAME": name, "SIZE": size}
             if description:
-                params['DESCRIPTION'] = description
+                params["DESCRIPTION"] = description
             return self.one.image.allocate(params)
         except pyone.OneException as e:
-            logger.exception('Failed to create volume')
+            logger.exception("Failed to create volume")
             raise OpenNebulaError(e)
 
     def delete_volume(self, volume_id):
@@ -416,7 +432,7 @@ class OpenNebulaClient:
         try:
             return self.one.image.delete(volume_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete volume')
+            logger.exception("Failed to delete volume")
             raise OpenNebulaError(e)
 
     def set_group_quota(self, group_id, quota_template):
@@ -432,7 +448,7 @@ class OpenNebulaClient:
         try:
             return self.one.group.quota(group_id, quota_template)
         except pyone.OneException as e:
-            logger.exception('Failed to set group quota')
+            logger.exception("Failed to set group quota")
             raise OpenNebulaError(e)
 
     def get_group_quota(self, group_id):
@@ -446,7 +462,7 @@ class OpenNebulaClient:
         try:
             return self.one.group.info(group_id).QUOTAS
         except pyone.OneException as e:
-            logger.exception('Failed to get group quota')
+            logger.exception("Failed to get group quota")
             raise OpenNebulaError(e)
 
     def update_network(self, network_id, template):
@@ -460,9 +476,11 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vn.update(network_id, _to_template_str(template), 1)  # 1 = merge
+            return self.one.vn.update(
+                network_id, _to_template_str(template), 1
+            )  # 1 = merge
         except pyone.OneException as e:
-            logger.exception('Failed to update network')
+            logger.exception("Failed to update network")
             raise OpenNebulaError(e)
 
     def add_ar(self, network_id, ar_template):
@@ -478,7 +496,7 @@ class OpenNebulaClient:
         try:
             return self.one.vn.add_ar(network_id, _to_template_str(ar_template))
         except pyone.OneException as e:
-            logger.exception('Failed to add address range to network')
+            logger.exception("Failed to add address range to network")
             raise OpenNebulaError(e)
 
     def rm_ar(self, network_id, ar_id, force=False):
@@ -496,7 +514,7 @@ class OpenNebulaClient:
         try:
             return self.one.vn.rm_ar(network_id, ar_id, force)
         except pyone.OneException as e:
-            logger.exception('Failed to remove address range from network')
+            logger.exception("Failed to remove address range from network")
             raise OpenNebulaError(e)
 
     def update_ar(self, network_id, ar_template):
@@ -512,7 +530,7 @@ class OpenNebulaClient:
         try:
             return self.one.vn.update_ar(network_id, _to_template_str(ar_template))
         except pyone.OneException as e:
-            logger.exception('Failed to update address range')
+            logger.exception("Failed to update address range")
             raise OpenNebulaError(e)
 
     def reserve_ar(self, network_id, reservation_template):
@@ -526,9 +544,11 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vn.reserve(network_id, _to_template_str(reservation_template))
+            return self.one.vn.reserve(
+                network_id, _to_template_str(reservation_template)
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to reserve address range')
+            logger.exception("Failed to reserve address range")
             raise OpenNebulaError(e)
 
     def create_disk_snapshot(self, vm_id, disk_id, description=None):
@@ -546,7 +566,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotcreate(vm_id, disk_id, description or "")
         except pyone.OneException as e:
-            logger.exception('Failed to create disk snapshot')
+            logger.exception("Failed to create disk snapshot")
             raise OpenNebulaError(e)
 
     def delete_disk_snapshot(self, vm_id, disk_id, snapshot_id):
@@ -564,7 +584,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotdelete(vm_id, disk_id, snapshot_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete disk snapshot')
+            logger.exception("Failed to delete disk snapshot")
             raise OpenNebulaError(e)
 
     def revert_disk_snapshot(self, vm_id, disk_id, snapshot_id):
@@ -582,7 +602,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotrevert(vm_id, disk_id, snapshot_id)
         except pyone.OneException as e:
-            logger.exception('Failed to revert disk snapshot')
+            logger.exception("Failed to revert disk snapshot")
             raise OpenNebulaError(e)
 
     def rename_disk_snapshot(self, vm_id, disk_id, snapshot_id, new_name):
@@ -602,7 +622,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotrename(vm_id, disk_id, snapshot_id, new_name)
         except pyone.OneException as e:
-            logger.exception('Failed to rename disk snapshot')
+            logger.exception("Failed to rename disk snapshot")
             raise OpenNebulaError(e)
 
     def resize_disk(self, vm_id, disk_id, size):
@@ -620,10 +640,12 @@ class OpenNebulaClient:
         try:
             return self.one.vm.diskresize(vm_id, disk_id, size)
         except pyone.OneException as e:
-            logger.exception('Failed to resize disk')
+            logger.exception("Failed to resize disk")
             raise OpenNebulaError(e)
 
-    def save_disk_as_image(self, vm_id, disk_id, image_name, image_type="", snapshot_id=-1):
+    def save_disk_as_image(
+        self, vm_id, disk_id, image_name, image_type="", snapshot_id=-1
+    ):
         """
         Saves the disk as a new image.
         :param vm_id: VM identifier
@@ -640,15 +662,19 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.disksaveas(vm_id, disk_id, image_name, image_type, snapshot_id)
+            return self.one.vm.disksaveas(
+                vm_id, disk_id, image_name, image_type, snapshot_id
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to save disk as image')
+            logger.exception("Failed to save disk as image")
             raise OpenNebulaError(e)
 
-    def migrate_vm(self, vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0):
+    def migrate_vm(
+        self, vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0
+    ):
         """
         Migrate a VM to a target host.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param host_id: Destination host identifier
@@ -665,15 +691,17 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.migrate(vm_id, host_id, live, enforce, ds_id, migration_type)
+            return self.one.vm.migrate(
+                vm_id, host_id, live, enforce, ds_id, migration_type
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to migrate VM')
+            logger.exception("Failed to migrate VM")
             raise OpenNebulaError(e)
 
     def disksaveas(self, vm_id, disk_id, image_name, image_type=None, snapshot_id=None):
         """
         Save a disk as a new image.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -688,15 +716,17 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vm.disksaveas(vm_id, disk_id, image_name, image_type or '', snapshot_id or -1)
+            return self.one.vm.disksaveas(
+                vm_id, disk_id, image_name, image_type or "", snapshot_id or -1
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to save disk as image')
+            logger.exception("Failed to save disk as image")
             raise OpenNebulaError(e)
 
     def disksnapshotcreate(self, vm_id, disk_id, description=None):
         """
         Create a new snapshot of a disk.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -709,13 +739,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotcreate(vm_id, disk_id, description or "")
         except pyone.OneException as e:
-            logger.exception('Failed to create disk snapshot')
+            logger.exception("Failed to create disk snapshot")
             raise OpenNebulaError(e)
 
     def disksnapshotdelete(self, vm_id, disk_id, snapshot_id):
         """
         Delete a disk snapshot.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -728,13 +758,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotdelete(vm_id, disk_id, snapshot_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete disk snapshot')
+            logger.exception("Failed to delete disk snapshot")
             raise OpenNebulaError(e)
 
     def disksnapshotrevert(self, vm_id, disk_id, snapshot_id):
         """
         Revert disk state to a previously taken snapshot.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -747,13 +777,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotrevert(vm_id, disk_id, snapshot_id)
         except pyone.OneException as e:
-            logger.exception('Failed to revert disk snapshot')
+            logger.exception("Failed to revert disk snapshot")
             raise OpenNebulaError(e)
 
     def disksnapshotrename(self, vm_id, disk_id, snapshot_id, new_name):
         """
         Rename a disk snapshot.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -768,13 +798,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.disksnapshotrename(vm_id, disk_id, snapshot_id, new_name)
         except pyone.OneException as e:
-            logger.exception('Failed to rename disk snapshot')
+            logger.exception("Failed to rename disk snapshot")
             raise OpenNebulaError(e)
 
     def diskresize(self, vm_id, disk_id, size):
         """
         Resize a disk attached to a VM.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param disk_id: Disk identifier
@@ -787,13 +817,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.diskresize(vm_id, disk_id, size)
         except pyone.OneException as e:
-            logger.exception('Failed to resize disk')
+            logger.exception("Failed to resize disk")
             raise OpenNebulaError(e)
 
     def backup_vm(self, vm_id, ds_id, reset=False):
         """
         Take a one-shot backup of a VM.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param ds_id: Destination datastore identifier for the backup
@@ -806,13 +836,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.backup(vm_id, ds_id, reset)
         except pyone.OneException as e:
-            logger.exception('Failed to backup VM')
+            logger.exception("Failed to backup VM")
             raise OpenNebulaError(e)
 
     def backup_cancel(self, vm_id):
         """
         Cancel an ongoing backup operation for a VM.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :return: Success status
@@ -821,13 +851,13 @@ class OpenNebulaClient:
         try:
             return self.one.vm.backupcancel(vm_id)
         except pyone.OneException as e:
-            logger.exception('Failed to cancel VM backup')
+            logger.exception("Failed to cancel VM backup")
             raise OpenNebulaError(e)
 
     def restore_vm(self, vm_id, backup_id, in_place=True):
         """
         Restore a VM from a backup.
-        
+
         :param vm_id: VM identifier
         :type vm_id: int
         :param backup_id: Backup image or snapshot identifier
@@ -840,33 +870,33 @@ class OpenNebulaClient:
         try:
             return self.one.vm.restore(vm_id, backup_id, in_place)
         except pyone.OneException as e:
-            logger.exception('Failed to restore VM from backup')
+            logger.exception("Failed to restore VM from backup")
             raise OpenNebulaError(e)
 
     def list_templates(self):
         """
         List all available VM templates for deployment.
-        
+
         :return: Template pool information
         :raises OpenNebulaError: If the API call fails
         """
         try:
             return self.one.templatepool.info(-2, -1, -1, -1)
         except pyone.OneException as e:
-            logger.exception('Failed to list templates')
+            logger.exception("Failed to list templates")
             raise OpenNebulaError(e)
 
     def list_images(self):
         """
         List all available disk images for VM creation or disk attachment.
-        
+
         :return: Image pool information
         :raises OpenNebulaError: If the API call fails
         """
         try:
             return self.one.imagepool.info(-2, -1, -1, -1)
         except pyone.OneException as e:
-            logger.exception('Failed to list images')
+            logger.exception("Failed to list images")
             raise OpenNebulaError(e)
 
     def list_hosts(self):
@@ -878,7 +908,7 @@ class OpenNebulaClient:
         try:
             return self.one.hostpool.info()
         except pyone.OneException as e:
-            logger.exception('Failed to list hosts')
+            logger.exception("Failed to list hosts")
             raise OpenNebulaError(e)
 
     def get_host(self, host_id):
@@ -892,7 +922,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.info(host_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get host info')
+            logger.exception("Failed to get host info")
             raise OpenNebulaError(e)
 
     def create_host(self, name, im_mad, vmm_mad, vnm_mad, cluster_id=None):
@@ -914,7 +944,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.allocate(name, im_mad, vmm_mad, vnm_mad, cluster_id)
         except pyone.OneException as e:
-            logger.exception('Failed to create host')
+            logger.exception("Failed to create host")
             raise OpenNebulaError(e)
 
     def delete_host(self, host_id):
@@ -927,7 +957,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.delete(host_id)
         except pyone.OneException as e:
-            logger.exception('Failed to delete host')
+            logger.exception("Failed to delete host")
             raise OpenNebulaError(e)
 
     def update_host(self, host_id, template, append=True):
@@ -945,7 +975,7 @@ class OpenNebulaClient:
             mode = 1 if append else 0
             return self.one.host.update(host_id, template, mode)
         except pyone.OneException as e:
-            logger.exception('Failed to update host')
+            logger.exception("Failed to update host")
             raise OpenNebulaError(e)
 
     def rename_host(self, host_id, new_name):
@@ -960,7 +990,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.rename(host_id, new_name)
         except pyone.OneException as e:
-            logger.exception('Failed to rename host')
+            logger.exception("Failed to rename host")
             raise OpenNebulaError(e)
 
     def set_host_status(self, host_id, status):
@@ -975,7 +1005,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.status(host_id, status)
         except pyone.OneException as e:
-            logger.exception('Failed to set host status')
+            logger.exception("Failed to set host status")
             raise OpenNebulaError(e)
 
     def get_host_monitoring(self, host_id):
@@ -989,7 +1019,7 @@ class OpenNebulaClient:
         try:
             return self.one.host.monitoring(host_id)
         except pyone.OneException as e:
-            logger.exception('Failed to get host monitoring')
+            logger.exception("Failed to get host monitoring")
             raise OpenNebulaError(e)
 
     def calculate_showback(self, start_month, start_year, end_month, end_year):
@@ -1007,9 +1037,11 @@ class OpenNebulaClient:
         :raises OpenNebulaError: If the API call fails
         """
         try:
-            return self.one.vmpool.calculateshowback(start_month, start_year, end_month, end_year)
+            return self.one.vmpool.calculateshowback(
+                start_month, start_year, end_month, end_year
+            )
         except pyone.OneException as e:
-            logger.exception('Failed to calculate showback')
+            logger.exception("Failed to calculate showback")
             raise OpenNebulaError(e)
 
     def attach_nic(self, vm_id, nic_template):
@@ -1024,7 +1056,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.attachnic(vm_id, _to_template_str(nic_template))
         except pyone.OneException as e:
-            logger.exception('Failed to attach NIC')
+            logger.exception("Failed to attach NIC")
             raise OpenNebulaError(e)
 
     def detach_nic(self, vm_id, nic_id):
@@ -1039,7 +1071,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.detachnic(vm_id, nic_id)
         except pyone.OneException as e:
-            logger.exception('Failed to detach NIC')
+            logger.exception("Failed to detach NIC")
             raise OpenNebulaError(e)
 
     def update_nic(self, vm_id, nic_id, nic_template):
@@ -1056,7 +1088,7 @@ class OpenNebulaClient:
         try:
             return self.one.vm.updatenic(vm_id, nic_id, _to_template_str(nic_template))
         except pyone.OneException as e:
-            logger.exception('Failed to update NIC')
+            logger.exception("Failed to update NIC")
             raise OpenNebulaError(e)
 
     def get_cpu(self, vm_id):
@@ -1096,9 +1128,8 @@ class OpenNebulaClient:
         :type spec: dict
         """
         try:
-            self.one.vm.update(int(vm_id), 'MEMORY = {}'.format(spec['size_MiB']))
+            self.one.vm.update(int(vm_id), "MEMORY = {}".format(spec["size_MiB"]))
         except pyone.OneException as e:
             raise OpenNebulaError(e)
-        
 
     # Add more methods for VM, tenant, network, etc. management as needed

--- a/src/waldur_opennebula/tasks.py
+++ b/src/waldur_opennebula/tasks.py
@@ -1,47 +1,66 @@
-# Place for OpenNebula Celery tasks 
-from celery import shared_task
-from waldur_opennebula.models import OpenNebulaVirtualMachine, OpenNebulaTenant, OpenNebulaVolume
-from waldur_opennebula.backend import OpenNebulaBackend
-from waldur_core.structure.models import ServiceSettings
-from .client import OpenNebulaClient
-from django.utils import timezone
+# Place for OpenNebula Celery tasks
 from datetime import timedelta
+
+from celery import shared_task
+from django.utils import timezone
+
+from waldur_core.structure.models import ServiceSettings
+from waldur_opennebula.backend import OpenNebulaBackend
+from waldur_opennebula.models import (
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+)
+
+from .client import OpenNebulaClient
 from .models import OpenNebulaScheduledAction
 
 
 @shared_task
-def create_vm_task(vm_id, service_settings_id, template_id, name, networks, cpu=None, ram=None, disk=None, ssh_key=None, contextualization=False, extra=None):
+def create_vm_task(
+    vm_id,
+    service_settings_id,
+    template_id,
+    name,
+    networks,
+    cpu=None,
+    ram=None,
+    disk=None,
+    ssh_key=None,
+    contextualization=False,
+    extra=None,
+):
     settings = ServiceSettings.objects.get(pk=service_settings_id)
-    client = OpenNebulaClient(settings.backend_url)
+    client = OpenNebulaClient(settings)
     params = extra.copy() if extra else {}
     if cpu is not None:
-        params['CPU'] = cpu
+        params["CPU"] = cpu
     if ram is not None:
-        params['MEMORY'] = ram
+        params["MEMORY"] = ram
     if disk is not None:
-        params['DISK_SIZE'] = disk
+        params["DISK_SIZE"] = disk
     if ssh_key:
-        params['SSH_PUBLIC_KEY'] = ssh_key
+        params["SSH_PUBLIC_KEY"] = ssh_key
     if contextualization:
-        params['CONTEXT'] = {'SSH_PUBLIC_KEY': ssh_key} if ssh_key else {}
-    params['NIC'] = [{'NETWORK_ID': net_id} for net_id in networks]
+        params["CONTEXT"] = {"SSH_PUBLIC_KEY": ssh_key} if ssh_key else {}
+    params["NIC"] = [{"NETWORK_ID": net_id} for net_id in networks]
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['state', 'progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["state", "progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
-        vm.backend_id = client.create_vm(template_id, name=name, extra=params)
+        vm.save(update_fields=["progress"])
+        if not vm.backend_id:
+            vm.backend_id = client.create_vm(template_id, name=name, extra=params)
         vm.set_ok()
         vm.progress = 100
-        vm.save(update_fields=['state', 'backend_id', 'progress'])
+        vm.save(update_fields=["state", "backend_id", "progress"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -49,43 +68,43 @@ def create_vm_task(vm_id, service_settings_id, template_id, name, networks, cpu=
 def delete_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.schedule_deleting()
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.delete_vm(vm)
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def start_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()  # Or a custom state for starting
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.start_vm(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def stop_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()  # Or a custom state for stopping
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.stop_vm(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -108,7 +127,7 @@ def delete_tenant_task(tenant_id):
         pass
 
 
-@shared_task(name='opennebula.pull_tenants_task')
+@shared_task(name="opennebula.pull_tenants_task")
 def pull_tenants_task(service_settings_id):
     settings = ServiceSettings.objects.get(pk=service_settings_id)
     backend = OpenNebulaBackend(settings)
@@ -120,26 +139,27 @@ def attach_disk_task(vm_id, disk_template):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.attach_disk(vm, disk_template)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
 @shared_task
 def detach_disk_task(vm_id, disk_id):
     from .models import OpenNebulaVolume
+
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     # Find the volume by disk_id if possible
@@ -149,30 +169,31 @@ def detach_disk_task(vm_id, disk_id):
         volume = None
     if volume:
         volume.progress = 0
-        volume.error_message = ''
-        volume.save(update_fields=['progress', 'error_message'])
+        volume.error_message = ""
+        volume.save(update_fields=["progress", "error_message"])
     try:
         if volume:
             volume.progress = 50
-            volume.save(update_fields=['progress'])
+            volume.save(update_fields=["progress"])
         backend.detach_disk(vm, disk_id)
         vm.set_ok()
         if volume:
             volume.progress = 100
-            volume.save(update_fields=['progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["progress"])
+        vm.save(update_fields=["state"])
     except Exception as e:
         vm.set_erred()
         if volume:
             volume.error_message = str(e)
             volume.progress = 0
-            volume.save(update_fields=['error_message', 'progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["error_message", "progress"])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def resize_disk_task(vm_id, disk_id, size):
     from .models import OpenNebulaVolume
+
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     try:
@@ -181,25 +202,25 @@ def resize_disk_task(vm_id, disk_id, size):
         volume = None
     if volume:
         volume.progress = 0
-        volume.error_message = ''
-        volume.save(update_fields=['progress', 'error_message'])
+        volume.error_message = ""
+        volume.save(update_fields=["progress", "error_message"])
     try:
         if volume:
             volume.progress = 50
-            volume.save(update_fields=['progress'])
+            volume.save(update_fields=["progress"])
         backend.resize_disk(vm, disk_id, size)
         vm.set_ok()
         if volume:
             volume.progress = 100
-            volume.save(update_fields=['progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["progress"])
+        vm.save(update_fields=["state"])
     except Exception as e:
         vm.set_erred()
         if volume:
             volume.error_message = str(e)
             volume.progress = 0
-            volume.save(update_fields=['error_message', 'progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["error_message", "progress"])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -209,10 +230,10 @@ def create_disk_snapshot_task(vm_id, disk_id, description=None):
     try:
         backend.create_disk_snapshot(vm, disk_id, description)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -222,10 +243,10 @@ def delete_disk_snapshot_task(vm_id, disk_id, snapshot_id):
     try:
         backend.delete_disk_snapshot(vm, disk_id, snapshot_id)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -235,10 +256,10 @@ def revert_disk_snapshot_task(vm_id, disk_id, snapshot_id):
     try:
         backend.revert_disk_snapshot(vm, disk_id, snapshot_id)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -248,10 +269,10 @@ def rename_disk_snapshot_task(vm_id, disk_id, snapshot_id, new_name):
     try:
         backend.rename_disk_snapshot(vm, disk_id, snapshot_id, new_name)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -259,20 +280,20 @@ def save_disk_as_image_task(vm_id, disk_id, image_name, image_type="", snapshot_
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.save_disk_as_image(vm, disk_id, image_name, image_type, snapshot_id)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -283,10 +304,10 @@ def backup_vm_task(vm_id, ds_id, reset=False):
     try:
         backend.backup_vm(vm, ds_id, reset)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -296,10 +317,10 @@ def backup_cancel_task(vm_id):
     try:
         backend.backup_cancel(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -309,115 +330,121 @@ def restore_vm_task(vm_id, backup_id, in_place=True):
     try:
         backend.restore_vm(vm, backup_id, in_place)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def add_ar_task(network_id, ar_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.add_ar(network, ar_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def rm_ar_task(network_id, ar_id, force=False):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.rm_ar(network, ar_id, force)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def update_ar_task(network_id, ar_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.update_ar(network, ar_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def reserve_ar_task(network_id, reservation_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.reserve_ar(network, reservation_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
-def migrate_vm_task(vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0):
+def migrate_vm_task(
+    vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0
+):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.migrate_vm(vm, host_id, live, enforce, ds_id, migration_type)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -426,20 +453,20 @@ def create_vm_snapshot_task(vm_id, name):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.create_snapshot(vm, name)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -448,20 +475,20 @@ def restore_vm_snapshot_task(vm_id, snapshot_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.restore_vm_snapshot(vm, snapshot_id)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -470,20 +497,20 @@ def create_backup_task(vm_id, name, description=None):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.create_backup(vm, name, description)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -493,17 +520,17 @@ def restore_backup_task(backup_id, vm_id=None, in_place=True, new_vm_name=None):
     backend = OpenNebulaBackend(vm.service_settings) if vm else None
     if vm:
         vm.progress = 0
-        vm.error_message = ''
-        vm.save(update_fields=['progress', 'error_message'])
+        vm.error_message = ""
+        vm.save(update_fields=["progress", "error_message"])
     try:
         if vm:
             if backend:
                 vm.progress = 50
-                vm.save(update_fields=['progress'])
+                vm.save(update_fields=["progress"])
                 backend.restore_backup(backup_id, vm, in_place, new_vm_name)
                 vm.progress = 100
                 vm.set_ok()
-                vm.save(update_fields=['progress', 'state'])
+                vm.save(update_fields=["progress", "state"])
         else:
             # For new VM, just call backend.restore_backup
             OpenNebulaBackend(None).restore_backup(backup_id, None, False, new_vm_name)
@@ -512,50 +539,57 @@ def restore_backup_task(backup_id, vm_id=None, in_place=True, new_vm_name=None):
             vm.set_erred()
             vm.error_message = str(e)
             vm.progress = 0
-            vm.save(update_fields=['state', 'error_message', 'progress'])
+            vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
 @shared_task
 def run_scheduled_actions():
     now = timezone.now()
-    for action in OpenNebulaScheduledAction.objects.filter(enabled=True, next_run__lte=now):
+    for action in OpenNebulaScheduledAction.objects.filter(
+        enabled=True, next_run__lte=now
+    ):
         try:
-            if action.action_type == 'snapshot':
-                create_vm_snapshot_task.delay(action.vm.pk, action.params.get('name', f"auto-{now:%Y%m%d%H%M}"))
-            elif action.action_type == 'backup':
-                create_backup_task.delay(action.vm.pk, action.params.get('name', f"auto-backup-{now:%Y%m%d%H%M}"))
+            if action.action_type == "snapshot":
+                create_vm_snapshot_task.delay(
+                    action.vm.pk, action.params.get("name", f"auto-{now:%Y%m%d%H%M}")
+                )
+            elif action.action_type == "backup":
+                create_backup_task.delay(
+                    action.vm.pk,
+                    action.params.get("name", f"auto-backup-{now:%Y%m%d%H%M}"),
+                )
             action.last_run = now
             # Calculate next_run based on interval
-            if action.interval == 'daily':
+            if action.interval == "daily":
                 action.next_run = now + timedelta(days=1)
-            elif action.interval == 'weekly':
+            elif action.interval == "weekly":
                 action.next_run = now + timedelta(weeks=1)
             # Add more interval logic as needed
-            action.error_message = ''
+            action.error_message = ""
         except Exception as e:
             action.error_message = str(e)
-        action.save() 
+        action.save()
 
 
 @shared_task
 def list_backups_task(vm_id):
     """
     Task to list all backups of a specific virtual machine.
-    
+
     Args:
         vm_id: ID of the OpenNebulaVirtualMachine
-        
+
     Returns:
         List of backups for the specified VM
     """
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
-    
+
     try:
         backups = backend.list_backups(vm)
         return backups
     except Exception as e:
         vm.error_message = f"Failed to list backups: {str(e)}"
-        vm.save(update_fields=['error_message'])
+        vm.save(update_fields=["error_message"])
         raise

--- a/src/waldur_opennebula/views.py
+++ b/src/waldur_opennebula/views.py
@@ -1,27 +1,64 @@
-from rest_framework import viewsets, status
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from .models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume, OpenNebulaScheduledAction
-from .serializers import OpenNebulaTenantSerializer, OpenNebulaTenantCreateSerializer, OpenNebulaVirtualMachineSerializer, OpenNebulaNetworkSerializer, OpenNebulaVolumeSerializer, OpenNebulaVMCreateSerializer, OpenNebulaVMMigrateSerializer, OpenNebulaDiskAttachSerializer, OpenNebulaDiskResizeSerializer, OpenNebulaDiskSaveAsSerializer, OpenNebulaVMSnapshotSerializer, OpenNebulaVMListSnapshotsSerializer, OpenNebulaBackupCreateSerializer, OpenNebulaBackupListSerializer, OpenNebulaRestoreBackupSerializer, OpenNebulaFloatingIPAssignSerializer, OpenNebulaFloatingIPReleaseSerializer, OpenNebulaMarketplaceOfferingSerializer, OpenNebulaVMMonitoringSerializer, OpenNebulaQuotaSerializer, OpenNebulaScheduledActionSerializer, OpenNebulaNetworkAttachSerializer, OpenNebulaNetworkReleaseSerializer, OpenNebulaNetworkUpdateSerializer, OpenNebulaNetworkListSerializer
-from .executors import (
-    AttachDiskExecutor, DetachDiskExecutor, NetworkDeleteExecutor,
-    VolumeDeleteExecutor, ResizeDiskExecutor,
-    CreateDiskSnapshotExecutor, DeleteDiskSnapshotExecutor,
-    RevertDiskSnapshotExecutor, RenameDiskSnapshotExecutor,
-    SaveDiskAsImageExecutor, BackupVMExecutor,
-    BackupCancelExecutor, RestoreVMExecutor, OpenNebulaCleanupExecutor,
-    VirtualMachineCreateExecutor, VirtualMachineDeleteExecutor,
-    VirtualMachinePullExecutor, VirtualMachineRebootExecutor,
-    VirtualMachineStartExecutor, VirtualMachineStopExecutor,
-    TenantPullExecutor, TenantDeleteExecutor
-)
-from .backend import OpenNebulaBackend
 from rest_framework.views import APIView
-from .client import OpenNebulaClient
+
 from waldur_core.structure.models import ServiceSettings
-from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiResponse
-from .tasks import create_vm_task, migrate_vm_task, attach_disk_task, resize_disk_task, save_disk_as_image_task, create_vm_snapshot_task, restore_vm_snapshot_task, create_backup_task, list_backups_task, restore_backup_task
-from django.shortcuts import get_object_or_404
+
+from .backend import OpenNebulaBackend
+from .client import OpenNebulaClient
+from .executors import (
+    TenantPullExecutor,
+    VirtualMachineCreateExecutor,
+    VirtualMachineDeleteExecutor,
+    VirtualMachineRebootExecutor,
+    VirtualMachineStartExecutor,
+    VirtualMachineStopExecutor,
+)
+from .models import (
+    OpenNebulaNetwork,
+    OpenNebulaScheduledAction,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+)
+from .serializers import (
+    OpenNebulaBackupCreateSerializer,
+    OpenNebulaBackupListSerializer,
+    OpenNebulaDiskAttachSerializer,
+    OpenNebulaDiskResizeSerializer,
+    OpenNebulaDiskSaveAsSerializer,
+    OpenNebulaMarketplaceOfferingSerializer,
+    OpenNebulaNetworkAttachSerializer,
+    OpenNebulaNetworkListSerializer,
+    OpenNebulaNetworkReleaseSerializer,
+    OpenNebulaNetworkSerializer,
+    OpenNebulaNetworkUpdateSerializer,
+    OpenNebulaQuotaSerializer,
+    OpenNebulaRestoreBackupSerializer,
+    OpenNebulaScheduledActionSerializer,
+    OpenNebulaTenantCreateSerializer,
+    OpenNebulaTenantSerializer,
+    OpenNebulaVirtualMachineSerializer,
+    OpenNebulaVMCreateSerializer,
+    OpenNebulaVMListSnapshotsSerializer,
+    OpenNebulaVMMigrateSerializer,
+    OpenNebulaVMMonitoringSerializer,
+    OpenNebulaVMSnapshotSerializer,
+    OpenNebulaVolumeSerializer,
+)
+from .tasks import (
+    attach_disk_task,
+    create_backup_task,
+    create_vm_snapshot_task,
+    create_vm_task,
+    migrate_vm_task,
+    resize_disk_task,
+    restore_backup_task,
+    save_disk_as_image_task,
+)
 
 
 class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
@@ -33,80 +70,115 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         backend = OpenNebulaBackend(request.user.service_settings)
         tenant = backend.create_tenant(
-            name=serializer.validated_data['name'],
-            description=serializer.validated_data.get('description', ''),
+            name=serializer.validated_data["name"],
+            description=serializer.validated_data.get("description", ""),
         )
-        return Response(OpenNebulaTenantSerializer(tenant).data, status=status.HTTP_201_CREATED)
+        return Response(
+            OpenNebulaTenantSerializer(tenant).data, status=status.HTTP_201_CREATED
+        )
 
-    @action(detail=True, methods=['delete'])
+    @action(detail=True, methods=["delete"])
     def delete_tenant(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
         backend.delete_tenant(tenant)
-        return Response({'detail': 'Tenant deleted.'}, status=status.HTTP_204_NO_CONTENT)
+        return Response(
+            {"detail": "Tenant deleted."}, status=status.HTTP_204_NO_CONTENT
+        )
 
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def pull(self, request):
-        service_settings_id = request.data.get('service_settings_id')
+        service_settings_id = request.data.get("service_settings_id")
         if not service_settings_id:
-            return Response({'detail': 'service_settings_id required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings_id required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         TenantPullExecutor.execute(service_settings_id)
-        return Response({'detail': 'Pull scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Pull scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def set_quotas(self, request, pk=None):
         tenant = self.get_object()
-        quota_template = request.data.get('quota_template')
+        quota_template = request.data.get("quota_template")
         if not quota_template:
-            return Response({'detail': 'quota_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "quota_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(tenant.service_settings)
         try:
             result = backend.set_tenant_quota(tenant, quota_template)
-            return Response({'detail': 'Quota set.', 'result': str(result)}, status=status.HTTP_200_OK)
+            return Response(
+                {"detail": "Quota set.", "result": str(result)},
+                status=status.HTTP_200_OK,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def pull_quotas(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
         try:
             quotas = backend.get_tenant_quota(tenant)
-            return Response({'quotas': str(quotas)}, status=status.HTTP_200_OK)
+            return Response({"quotas": str(quotas)}, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_network(self, request, pk=None):
         # This could be implemented if OpenNebula supports network creation per group/project
-        return Response({'detail': 'Network creation for tenant is not implemented yet.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Network creation for tenant is not implemented yet."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_floating_ip(self, request, pk=None):
         # OpenNebula does not have a direct floating IP concept like OpenStack
-        return Response({'detail': 'Floating IPs are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Floating IPs are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_floating_ips(self, request, pk=None):
         # OpenNebula does not have a direct floating IP concept like OpenStack
-        return Response({'detail': 'Floating IPs are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Floating IPs are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_security_groups(self, request, pk=None):
         # OpenNebula does not have security groups like OpenStack
-        return Response({'detail': 'Security groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Security groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_server_groups(self, request, pk=None):
         # OpenNebula does not have server groups like OpenStack
-        return Response({'detail': 'Server groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Server groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_server_group(self, request, pk=None):
         # OpenNebula does not have server groups like OpenStack
-        return Response({'detail': 'Server groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Server groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_instances(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -115,10 +187,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVirtualMachineSerializer(vms, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_vms(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -127,9 +200,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVirtualMachineSerializer(vms, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_volumes(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -138,9 +213,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVolumeSerializer(volumes, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_networks(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -149,369 +226,481 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaNetworkSerializer(networks, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaVirtualMachineViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaVirtualMachine.objects.all()
     serializer_class = OpenNebulaVirtualMachineSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def start(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineStartExecutor.execute(vm)
-        return Response({'detail': 'Start scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Start scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def reboot(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineRebootExecutor.execute(vm)
-        return Response({'detail': 'Start scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Start scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def stop(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineStopExecutor.execute(vm)
-        return Response({'detail': 'Stop scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Stop scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def delete_vm(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineDeleteExecutor.execute(vm)
-        return Response({'detail': 'Delete scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Delete scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         instance = serializer.save()
         VirtualMachineCreateExecutor.execute(instance)
-        return Response(self.get_serializer(instance).data, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            self.get_serializer(instance).data, status=status.HTTP_202_ACCEPTED
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restart(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.reboot_vm(vm)
-            return Response({'detail': 'Restart scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restart scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def resize(self, request, pk=None):
         vm = self.get_object()
-        cpu = request.data.get('cpu')
-        ram = request.data.get('ram')
+        cpu = request.data.get("cpu")
+        ram = request.data.get("ram")
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.resize_vm(vm, cpu=cpu, ram=ram)
-            return Response({'detail': 'Resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Resize scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def attach_volume(self, request, pk=None):
         vm = self.get_object()
-        volume_id = request.data.get('volume_id')
+        volume_id = request.data.get("volume_id")
         if not volume_id:
-            return Response({'detail': 'volume_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "volume_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         from .models import OpenNebulaVolume
+
         try:
             volume = OpenNebulaVolume.objects.get(pk=volume_id)
         except OpenNebulaVolume.DoesNotExist:
-            return Response({'detail': 'Volume not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "Volume not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.attach_disk(vm, volume)
-            return Response({'detail': 'Attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Attach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def detach_volume(self, request, pk=None):
         vm = self.get_object()
-        disk_id = request.data.get('disk_id')
+        disk_id = request.data.get("disk_id")
         if not disk_id:
-            return Response({'detail': 'disk_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "disk_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.detach_disk(vm, disk_id)
-            return Response({'detail': 'Detach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Detach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def snapshot(self, request, pk=None):
         vm = self.get_object()
-        name = request.data.get('name')
+        name = request.data.get("name")
         if not name:
-            return Response({'detail': 'name is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "name is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.snapshot_vm(vm, name)
-            return Response({'detail': 'Snapshot scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restore_snapshot(self, request, pk=None):
         vm = self.get_object()
-        snapshot_id = request.data.get('snapshot_id')
+        snapshot_id = request.data.get("snapshot_id")
         if not snapshot_id:
-            return Response({'detail': 'snapshot_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "snapshot_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.restore_vm_snapshot(vm, snapshot_id)
-            return Response({'detail': 'Restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restore scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def console(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             console_info = backend.get_console(vm)
-            return Response({'console': str(console_info)}, status=status.HTTP_200_OK)
+            return Response({"console": str(console_info)}, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def backup(self, request, pk=None):
         vm = self.get_object()
-        ds_id = request.data.get('ds_id')
-        reset = request.data.get('reset', False)
+        ds_id = request.data.get("ds_id")
+        reset = request.data.get("reset", False)
         if not ds_id:
-            return Response({'detail': 'ds_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ds_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.backup_vm(vm, ds_id, reset)
-            return Response({'detail': 'Backup scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Backup scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def backup_cancel(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.backup_cancel(vm)
-            return Response({'detail': 'Backup cancel scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Backup cancel scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restore(self, request, pk=None):
         vm = self.get_object()
-        backup_id = request.data.get('backup_id')
-        in_place = request.data.get('in_place', True)
+        backup_id = request.data.get("backup_id")
+        in_place = request.data.get("in_place", True)
         if not backup_id:
-            return Response({'detail': 'backup_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "backup_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.restore_vm(vm, backup_id, in_place)
-            return Response({'detail': 'Restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restore scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaVMCreateSerializer,
-        responses={201: OpenApiResponse(description='VM created'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a new VM with the selected template, networks, and options."
+        responses={
+            201: OpenApiResponse(description="VM created"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a new VM with the selected template, networks, and options.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_vm(self, request):
         serializer = OpenNebulaVMCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        settings = data['service_settings']
+        settings = data["service_settings"]
         # Create DB record for VM in 'creating' state
         vm = OpenNebulaVirtualMachine.objects.create(
-            name=data['name'],
+            name=data["name"],
             service_settings=settings,
-            state='creating',
+            state="creating",
             # Add other required fields as needed (e.g., project, tenant)
         )
         # Schedule async Celery task
-        create_vm_task(
+        create_vm_task.delay(
             vm.pk,
             settings.pk,
-            data['template_id'],
-            data['name'],
-            data['networks'],
-            data.get('cpu'),
-            data.get('ram'),
-            data.get('disk'),
-            data.get('ssh_key'),
-            data.get('contextualization', False),
-            data.get('extra', {}),
+            data["template_id"],
+            data["name"],
+            data["networks"],
+            data.get("cpu"),
+            data.get("ram"),
+            data.get("disk"),
+            data.get("ssh_key"),
+            data.get("contextualization", False),
+            data.get("extra", {}),
         )
         # Return VM object (with state) for polling
-        return Response(OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED)
+        return Response(
+            OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED
+        )
 
     @extend_schema(
         request=OpenNebulaVMMigrateSerializer,
-        responses={202: OpenApiResponse(description='Migration scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Migrate a VM to a target host/datastore."
+        responses={
+            202: OpenApiResponse(description="Migration scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Migrate a VM to a target host/datastore.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def migrate(self, request):
         serializer = OpenNebulaVMMigrateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        migrate_vm_task(
+        vm = data["vm"]
+        migrate_vm_task.delay(
             vm.pk,
-            data['host_id'],
-            data.get('live', True),
-            data.get('enforce', False),
-            data.get('ds_id'),
-            data.get('migration_type', 0),
+            data["host_id"],
+            data.get("live", True),
+            data.get("enforce", False),
+            data.get("ds_id"),
+            data.get("migration_type", 0),
         )
-        return Response({'detail': 'Migration scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Migration scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskAttachSerializer,
-        responses={202: OpenApiResponse(description='Disk attach scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Attach a disk/image to a VM."
+        responses={
+            202: OpenApiResponse(description="Disk attach scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Attach a disk/image to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def attach_disk(self, request):
         serializer = OpenNebulaDiskAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         disk_template = {
-            'IMAGE_ID': data['image_id'],
+            "IMAGE_ID": data["image_id"],
         }
-        if data.get('size'):
-            disk_template['SIZE'] = data['size']
-        if data.get('type'):
-            disk_template['TYPE'] = data['type']
-        if data.get('target'):
-            disk_template['TARGET'] = data['target']
-        attach_disk_task(vm.pk, disk_template)
-        return Response({'detail': 'Disk attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        if data.get("size"):
+            disk_template["SIZE"] = data["size"]
+        if data.get("type"):
+            disk_template["TYPE"] = data["type"]
+        if data.get("target"):
+            disk_template["TARGET"] = data["target"]
+        attach_disk_task.delay(vm.pk, disk_template)
+        return Response(
+            {"detail": "Disk attach scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskResizeSerializer,
-        responses={202: OpenApiResponse(description='Disk resize scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Resize a disk attached to a VM."
+        responses={
+            202: OpenApiResponse(description="Disk resize scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Resize a disk attached to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def resize_disk(self, request):
         serializer = OpenNebulaDiskResizeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        resize_disk_task(vm.pk, data['disk_id'], data['size'])
-        return Response({'detail': 'Disk resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        vm = data["vm"]
+        resize_disk_task.delay(vm.pk, data["disk_id"], data["size"])
+        return Response(
+            {"detail": "Disk resize scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskSaveAsSerializer,
-        responses={202: OpenApiResponse(description='Save disk as image scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Save a disk as a new image."
+        responses={
+            202: OpenApiResponse(description="Save disk as image scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Save a disk as a new image.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def save_disk_as_image(self, request):
         serializer = OpenNebulaDiskSaveAsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        save_disk_as_image_task(
+        vm = data["vm"]
+        save_disk_as_image_task.delay(
             vm.pk,
-            data['disk_id'],
-            data['image_name'],
-            data.get('image_type', ''),
-            data.get('snapshot_id', -1),
+            data["disk_id"],
+            data["image_name"],
+            data.get("image_type", ""),
+            data.get("snapshot_id", -1),
         )
-        return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaVMSnapshotSerializer,
-        responses={202: OpenApiResponse(description='Snapshot creation scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a snapshot for a VM."
+        responses={
+            202: OpenApiResponse(description="Snapshot creation scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a snapshot for a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_snapshot(self, request):
         serializer = OpenNebulaVMSnapshotSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_vm_snapshot_task(data['vm'].pk, data['name'])
-        return Response({'detail': 'Snapshot creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_vm_snapshot_task.delay(data["vm"].pk, data["name"])
+        return Response(
+            {"detail": "Snapshot creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaVMListSnapshotsSerializer,
-        responses={200: OpenApiResponse(description='List of VM snapshots'), 400: OpenApiResponse(description='Validation error')},
-        description="List all snapshots for a VM."
+        responses={
+            200: OpenApiResponse(description="List of VM snapshots"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="List all snapshots for a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_snapshots(self, request):
         serializer = OpenNebulaVMListSnapshotsSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             snapshots = backend.list_snapshots(vm)
             return Response(snapshots, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaBackupCreateSerializer,
-        responses={202: OpenApiResponse(description='Backup creation scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a backup for a VM."
+        responses={
+            202: OpenApiResponse(description="Backup creation scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a backup for a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_backup(self, request):
         serializer = OpenNebulaBackupCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_backup_task(data['vm'].pk, data['name'], data.get('description', ''))
-        return Response({'detail': 'Backup creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_backup_task.delay(
+            data["vm"].pk, data["name"], data.get("description", "")
+        )
+        return Response(
+            {"detail": "Backup creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaBackupListSerializer,
-        responses={200: OpenApiResponse(description='List of VM backups'), 400: OpenApiResponse(description='Validation error')},
-        description="List all backups for a VM."
+        responses={
+            200: OpenApiResponse(description="List of VM backups"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="List all backups for a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_backups(self, request):
         serializer = OpenNebulaBackupListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             backups = backend.list_backups(vm)
             return Response(backups, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaRestoreBackupSerializer,
-        responses={202: OpenApiResponse(description='Backup restore scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Restore a backup to a VM or as a new VM."
+        responses={
+            202: OpenApiResponse(description="Backup restore scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Restore a backup to a VM or as a new VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def restore_backup(self, request):
         serializer = OpenNebulaRestoreBackupSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        restore_backup_task(
-            data['backup_id'],
-            data.get('vm').pk if data.get('vm') else None,
-            data.get('in_place', True),
-            data.get('new_vm_name', ''),
+        restore_backup_task.delay(
+            data["backup_id"],
+            data.get("vm").pk if data.get("vm") else None,
+            data.get("in_place", True),
+            data.get("new_vm_name", ""),
         )
-        return Response({'detail': 'Backup restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Backup restore scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer)},
-        description="Get monitoring data for a VM."
+        description="Get monitoring data for a VM.",
     )
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def monitoring(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
@@ -520,619 +709,920 @@ class OpenNebulaVirtualMachineViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer(many=True))},
-        description="Get monitoring data for all VMs."
+        description="Get monitoring data for all VMs.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def pool_monitoring(self, request):
         # Optionally filter by user/project
-        backend = OpenNebulaBackend(ServiceSettings.objects.filter(type='OpenNebula').first())
+        backend = OpenNebulaBackend(
+            ServiceSettings.objects.filter(type="OpenNebula").first()
+        )
         data = backend.get_vmpool_monitoring()
         return Response(data, status=status.HTTP_200_OK)
 
     @extend_schema(
         request=OpenNebulaNetworkAttachSerializer,
-        responses={200: OpenApiResponse(description='NIC attached'), 400: OpenApiResponse(description='Validation error')},
-        description="Attach a network interface to a VM."
+        responses={
+            200: OpenApiResponse(description="NIC attached"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Attach a network interface to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def attach_nic(self, request):
         serializer = OpenNebulaNetworkAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
+            backend = OpenNebulaBackend(data["vm"].service_settings)
             result = backend.attach_nic(
-                data['vm'], 
-                data['network_id'], 
-                ip=data.get('ip_address'), 
-                model=data.get('model')
+                data["vm"],
+                data["network_id"],
+                ip=data.get("ip_address"),
+                model=data.get("model"),
             )
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaNetworkReleaseSerializer,
-        responses={200: OpenApiResponse(description='NIC detached'), 400: OpenApiResponse(description='Validation error')},
-        description="Detach a network interface from a VM."
+        responses={
+            200: OpenApiResponse(description="NIC detached"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Detach a network interface from a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def detach_nic(self, request):
         serializer = OpenNebulaNetworkReleaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            result = backend.detach_nic(data['vm'], data['nic_id'])
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+            result = backend.detach_nic(data["vm"], data["nic_id"])
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaNetworkUpdateSerializer,
-        responses={200: OpenApiResponse(description='NIC updated'), 400: OpenApiResponse(description='Validation error')},
-        description="Update a network interface configuration."
+        responses={
+            200: OpenApiResponse(description="NIC updated"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Update a network interface configuration.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def update_nic(self, request):
         serializer = OpenNebulaNetworkUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+
             # Extract kwargs from the validated data, removing vm and nic_id
-            kwargs = {k: v for k, v in data.items() if k not in ['vm', 'nic_id']}
-            
-            result = backend.update_nic(data['vm'], data['nic_id'], **kwargs)
+            kwargs = {k: v for k, v in data.items() if k not in ["vm", "nic_id"]}
+
+            result = backend.update_nic(data["vm"], data["nic_id"], **kwargs)
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         request=OpenNebulaNetworkListSerializer,
-        responses={200: OpenApiResponse(description='List of NICs attached to VM')},
-        description="List all network interfaces attached to a VM."
+        responses={200: OpenApiResponse(description="List of NICs attached to VM")},
+        description="List all network interfaces attached to a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_nics(self, request):
         serializer = OpenNebulaNetworkListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            nics = backend.list_nics(data['vm'])
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+            nics = backend.list_nics(data["vm"])
             return Response(nics, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaNetworkViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaNetwork.objects.all()
     serializer_class = OpenNebulaNetworkSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def update_network(self, request, pk=None):
         network = self.get_object()
-        template = request.data.get('template')
+        template = request.data.get("template")
         if not template:
-            return Response({'detail': 'template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "template is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.update_network(network, template)
-            return Response({'detail': 'Network update scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Network update scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def add_ar(self, request, pk=None):
         network = self.get_object()
-        ar_template = request.data.get('ar_template')
+        ar_template = request.data.get("ar_template")
         if not ar_template:
-            return Response({'detail': 'ar_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.add_ar(network, ar_template)
-            return Response({'detail': 'Address range add scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range add scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def rm_ar(self, request, pk=None):
         network = self.get_object()
-        ar_id = request.data.get('ar_id')
-        force = request.data.get('force', False)
+        ar_id = request.data.get("ar_id")
+        force = request.data.get("force", False)
         if ar_id is None:
-            return Response({'detail': 'ar_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.rm_ar(network, ar_id, force)
-            return Response({'detail': 'Address range remove scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range remove scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def update_ar(self, request, pk=None):
         network = self.get_object()
-        ar_template = request.data.get('ar_template')
+        ar_template = request.data.get("ar_template")
         if not ar_template:
-            return Response({'detail': 'ar_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.update_ar(network, ar_template)
-            return Response({'detail': 'Address range update scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range update scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def reserve_ar(self, request, pk=None):
         network = self.get_object()
-        reservation_template = request.data.get('reservation_template')
+        reservation_template = request.data.get("reservation_template")
         if not reservation_template:
-            return Response({'detail': 'reservation_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "reservation_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.reserve_ar(network, reservation_template)
-            return Response({'detail': 'Address reservation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address reservation scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of networks')},
-        description="List available networks for VM deployment."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of networks")},
+        description="List available networks for VM deployment.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_all(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             networks = client.list_networks()
             data = [
-                {'id': n.ID, 'name': n.NAME, 'bridge': getattr(n, 'BRIDGE', None), 'vlan_id': getattr(n, 'VLAN_ID', None)}
-                for n in getattr(networks, 'VNET', [])
+                {
+                    "id": n.ID,
+                    "name": n.NAME,
+                    "bridge": getattr(n, "BRIDGE", None),
+                    "vlan_id": getattr(n, "VLAN_ID", None),
+                }
+                for n in getattr(networks, "VNET", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaVolumeViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaVolume.objects.all()
     serializer_class = OpenNebulaVolumeSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def attach_to_vm(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
+        vm_id = request.data.get("vm_id")
         if not vm_id:
-            return Response({'detail': 'vm_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.attach_disk(vm, volume)
-            return Response({'detail': 'Attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Attach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def detach_from_vm(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
         if not vm_id or not disk_id:
-            return Response({'detail': 'vm_id and disk_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id and disk_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.detach_disk(vm, disk_id)
-            return Response({'detail': 'Detach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Detach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        description = request.data.get('description')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        description = request.data.get("description")
         if not vm_id or not disk_id:
-            return Response({'detail': 'vm_id and disk_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id and disk_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.create_disk_snapshot(vm, disk_id, description)
-            return Response({'detail': 'Snapshot scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def delete_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
         if not vm_id or not disk_id or not snapshot_id:
-            return Response({'detail': 'vm_id, disk_id, and snapshot_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and snapshot_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.delete_disk_snapshot(vm, disk_id, snapshot_id)
-            return Response({'detail': 'Snapshot delete scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot delete scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def revert_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
         if not vm_id or not disk_id or not snapshot_id:
-            return Response({'detail': 'vm_id, disk_id, and snapshot_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and snapshot_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.revert_disk_snapshot(vm, disk_id, snapshot_id)
-            return Response({'detail': 'Snapshot revert scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot revert scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def rename_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
-        new_name = request.data.get('new_name')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
+        new_name = request.data.get("new_name")
         if not vm_id or not disk_id or not snapshot_id or not new_name:
-            return Response({'detail': 'vm_id, disk_id, snapshot_id, and new_name are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, snapshot_id, and new_name are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.rename_disk_snapshot(vm, disk_id, snapshot_id, new_name)
-            return Response({'detail': 'Snapshot rename scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot rename scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def resize(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        size = request.data.get('size')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        size = request.data.get("size")
         if not vm_id or not disk_id or not size:
-            return Response({'detail': 'vm_id, disk_id, and size are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and size are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.resize_disk(vm, disk_id, size)
-            return Response({'detail': 'Resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Resize scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def save_as_image(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        image_name = request.data.get('image_name')
-        image_type = request.data.get('image_type', "")
-        snapshot_id = request.data.get('snapshot_id', -1)
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        image_name = request.data.get("image_name")
+        image_type = request.data.get("image_type", "")
+        snapshot_id = request.data.get("snapshot_id", -1)
         if not vm_id or not disk_id or not image_name:
-            return Response({'detail': 'vm_id, disk_id, and image_name are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and image_name are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.save_disk_as_image(vm, disk_id, image_name, image_type, snapshot_id)
-            return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
-    parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-    responses={200: OpenApiResponse(description='List of VM templates')},
-    description="List available VM templates for deployment."
+    parameters=[
+        OpenApiParameter(
+            "service_settings", type=int, required=True, location=OpenApiParameter.QUERY
+        )
+    ],
+    responses={200: OpenApiResponse(description="List of VM templates")},
+    description="List available VM templates for deployment.",
 )
 class OpenNebulaTemplateListView(APIView):
     def get(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             templates = client.list_templates()
             # Minimal serialization for wizard
             data = [
-                {'id': t.ID, 'name': t.NAME, 'cpu': getattr(t.TEMPLATE, 'CPU', None), 'memory': getattr(t.TEMPLATE, 'MEMORY', None)}
-                for t in getattr(templates, 'VMTEMPLATE', [])
+                {
+                    "id": t.ID,
+                    "name": t.NAME,
+                    "cpu": getattr(t.TEMPLATE, "CPU", None),
+                    "memory": getattr(t.TEMPLATE, "MEMORY", None),
+                }
+                for t in getattr(templates, "VMTEMPLATE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
-    parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-    responses={200: OpenApiResponse(description='List of images')},
-    description="List available images for disk attach or VM creation."
+    parameters=[
+        OpenApiParameter(
+            "service_settings", type=int, required=True, location=OpenApiParameter.QUERY
+        )
+    ],
+    responses={200: OpenApiResponse(description="List of images")},
+    description="List available images for disk attach or VM creation.",
 )
 class OpenNebulaImageListView(APIView):
     def get(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             images = client.list_images()
             data = [
-                {'id': i.ID, 'name': i.NAME, 'size': getattr(i, 'SIZE', None), 'type': getattr(i, 'TYPE', None)}
-                for i in getattr(images, 'IMAGE', [])
+                {
+                    "id": i.ID,
+                    "name": i.NAME,
+                    "size": getattr(i, "SIZE", None),
+                    "type": getattr(i, "TYPE", None),
+                }
+                for i in getattr(images, "IMAGE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
     request=OpenNebulaVMCreateSerializer,
-    responses={201: OpenApiResponse(description='VM created'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a new VM with the selected template, networks, and options."
+    responses={
+        201: OpenApiResponse(description="VM created"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a new VM with the selected template, networks, and options.",
 )
 class OpenNebulaVMCreateView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        settings = data['service_settings']
-        # Create DB record for VM in 'creating' state
-        vm = OpenNebulaVirtualMachine.objects.create(
-            name=data['name'],
-            service_settings=settings,
-            state='creating',
-            # Add other required fields as needed (e.g., project, tenant)
-        )
-        # Schedule async Celery task
-        create_vm_task(
-            vm.pk,
-            settings.pk,
-            data['template_id'],
-            data['name'],
-            data['networks'],
-            data.get('cpu'),
-            data.get('ram'),
-            data.get('disk'),
-            data.get('ssh_key'),
-            data.get('contextualization', False),
-            data.get('extra', {}),
-        )
-        # Return VM object (with state) for polling
-        return Response(OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED)
+        settings = data["service_settings"]
+        client = OpenNebulaClient(settings)
+
+        params = data.get("extra", {}).copy()
+        if data.get("cpu") is not None:
+            params["CPU"] = data["cpu"]
+        if data.get("ram") is not None:
+            params["MEMORY"] = data["ram"]
+        if data.get("disk") is not None:
+            params["DISK_SIZE"] = data["disk"]
+        ssh_key = data.get("ssh_key")
+        if ssh_key:
+            params["SSH_PUBLIC_KEY"] = ssh_key
+        if data.get("contextualization", False):
+            params["CONTEXT"] = {"SSH_PUBLIC_KEY": ssh_key} if ssh_key else {}
+        params["NIC"] = [{"NETWORK_ID": net_id} for net_id in data["networks"]]
+
+        try:
+            backend_vm_id = client.create_vm(
+                data["template_id"],
+                name=data["name"],
+                extra=params or None,
+            )
+        except Exception as exc:
+            return Response(
+                {"detail": str(exc)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+        vm = None
+        tenant = OpenNebulaTenant.objects.filter(service_settings=settings).first()
+        if tenant:
+            vm = OpenNebulaVirtualMachine.objects.create(
+                name=data["name"],
+                service_settings=settings,
+                tenant=tenant,
+                project=tenant.project,
+                backend_id=str(backend_vm_id),
+            )
+            create_vm_task.delay(
+                vm.pk,
+                settings.pk,
+                data["template_id"],
+                data["name"],
+                data["networks"],
+                data.get("cpu"),
+                data.get("ram"),
+                data.get("disk"),
+                ssh_key,
+                data.get("contextualization", False),
+                data.get("extra", {}),
+            )
+
+        return Response({"vm_id": backend_vm_id}, status=status.HTTP_201_CREATED)
+
 
 @extend_schema(
     request=OpenNebulaVMMigrateSerializer,
-    responses={202: OpenApiResponse(description='Migration scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Migrate a VM to a target host/datastore."
+    responses={
+        202: OpenApiResponse(description="Migration scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Migrate a VM to a target host/datastore.",
 )
 class OpenNebulaVMMigrateView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMMigrateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        migrate_vm_task(
+        vm = data["vm"]
+        migrate_vm_task.delay(
             vm.pk,
-            data['host_id'],
-            data.get('live', True),
-            data.get('enforce', False),
-            data.get('ds_id'),
-            data.get('migration_type', 0),
+            data["host_id"],
+            data.get("live", True),
+            data.get("enforce", False),
+            data.get("ds_id"),
+            data.get("migration_type", 0),
         )
-        return Response({'detail': 'Migration scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Migration scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskAttachSerializer,
-    responses={202: OpenApiResponse(description='Disk attach scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Attach a disk/image to a VM."
+    responses={
+        202: OpenApiResponse(description="Disk attach scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Attach a disk/image to a VM.",
 )
 class OpenNebulaDiskAttachView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         disk_template = {
-            'IMAGE_ID': data['image_id'],
+            "IMAGE_ID": data["image_id"],
         }
-        if data.get('size'):
-            disk_template['SIZE'] = data['size']
-        if data.get('type'):
-            disk_template['TYPE'] = data['type']
-        if data.get('target'):
-            disk_template['TARGET'] = data['target']
-        attach_disk_task(vm.pk, disk_template)
-        return Response({'detail': 'Disk attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        if data.get("size"):
+            disk_template["SIZE"] = data["size"]
+        if data.get("type"):
+            disk_template["TYPE"] = data["type"]
+        if data.get("target"):
+            disk_template["TARGET"] = data["target"]
+        attach_disk_task.delay(vm.pk, disk_template)
+        return Response(
+            {"detail": "Disk attach scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskResizeSerializer,
-    responses={202: OpenApiResponse(description='Disk resize scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Resize a disk attached to a VM."
+    responses={
+        202: OpenApiResponse(description="Disk resize scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Resize a disk attached to a VM.",
 )
 class OpenNebulaDiskResizeView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskResizeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        resize_disk_task(vm.pk, data['disk_id'], data['size'])
-        return Response({'detail': 'Disk resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        vm = data["vm"]
+        resize_disk_task.delay(vm.pk, data["disk_id"], data["size"])
+        return Response(
+            {"detail": "Disk resize scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskSaveAsSerializer,
-    responses={202: OpenApiResponse(description='Save disk as image scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Save a disk as a new image."
+    responses={
+        202: OpenApiResponse(description="Save disk as image scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Save a disk as a new image.",
 )
 class OpenNebulaDiskSaveAsView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskSaveAsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        save_disk_as_image_task(
+        vm = data["vm"]
+        save_disk_as_image_task.delay(
             vm.pk,
-            data['disk_id'],
-            data['image_name'],
-            data.get('image_type', ''),
-            data.get('snapshot_id', -1),
+            data["disk_id"],
+            data["image_name"],
+            data.get("image_type", ""),
+            data.get("snapshot_id", -1),
         )
-        return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaVMSnapshotSerializer,
-    responses={202: OpenApiResponse(description='Snapshot creation scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a snapshot for a VM."
+    responses={
+        202: OpenApiResponse(description="Snapshot creation scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a snapshot for a VM.",
 )
 class OpenNebulaVMSnapshotView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMSnapshotSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_vm_snapshot_task(data['vm'].pk, data['name'])
-        return Response({'detail': 'Snapshot creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_vm_snapshot_task.delay(data["vm"].pk, data["name"])
+        return Response(
+            {"detail": "Snapshot creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaVMListSnapshotsSerializer,
-    responses={200: OpenApiResponse(description='List of VM snapshots'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="List all snapshots for a VM."
+    responses={
+        200: OpenApiResponse(description="List of VM snapshots"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List all snapshots for a VM.",
 )
 class OpenNebulaVMListSnapshotsView(APIView):
     def get(self, request):
         serializer = OpenNebulaVMListSnapshotsSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         # Assume backend.list_snapshots(vm) returns a list of dicts
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             snapshots = backend.list_snapshots(vm)
             return Response(snapshots, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     request=OpenNebulaBackupCreateSerializer,
-    responses={202: OpenApiResponse(description='Backup creation scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a backup for a VM."
+    responses={
+        202: OpenApiResponse(description="Backup creation scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a backup for a VM.",
 )
 class OpenNebulaBackupCreateView(APIView):
     def post(self, request):
         serializer = OpenNebulaBackupCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_backup_task(data['vm'].pk, data['name'], data.get('description', ''))
-        return Response({'detail': 'Backup creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_backup_task.delay(
+            data["vm"].pk, data["name"], data.get("description", "")
+        )
+        return Response(
+            {"detail": "Backup creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaBackupListSerializer,
-    responses={200: OpenApiResponse(description='List of VM backups'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="List all backups for a VM."
+    responses={
+        200: OpenApiResponse(description="List of VM backups"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List all backups for a VM.",
 )
 class OpenNebulaBackupListView(APIView):
     def get(self, request):
         serializer = OpenNebulaBackupListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             backups = backend.list_backups(vm)
             return Response(backups, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     request=OpenNebulaRestoreBackupSerializer,
-    responses={202: OpenApiResponse(description='Backup restore scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Restore a backup to a VM or as a new VM."
+    responses={
+        202: OpenApiResponse(description="Backup restore scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Restore a backup to a VM or as a new VM.",
 )
 class OpenNebulaRestoreBackupView(APIView):
     def post(self, request):
         serializer = OpenNebulaRestoreBackupSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        restore_backup_task(
-            data['backup_id'],
-            data.get('vm').pk if data.get('vm') else None,
-            data.get('in_place', True),
-            data.get('new_vm_name', ''),
+        restore_backup_task.delay(
+            data["backup_id"],
+            data.get("vm").pk if data.get("vm") else None,
+            data.get("in_place", True),
+            data.get("new_vm_name", ""),
         )
-        return Response({'detail': 'Backup restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Backup restore scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
-    responses={200: OpenApiResponse(OpenNebulaMarketplaceOfferingSerializer(many=True)), 500: OpenApiResponse(description='Backend error')},
-    description="List available marketplace offerings (templates/images)."
+    responses={
+        200: OpenApiResponse(OpenNebulaMarketplaceOfferingSerializer(many=True)),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List available marketplace offerings (templates/images).",
 )
 class OpenNebulaMarketplaceOfferingListView(APIView):
     def get(self, request):
         try:
             # Use the first available service_settings for demonstration; in production, filter by user/project
             from waldur_core.structure.models import ServiceSettings
-            settings = ServiceSettings.objects.filter(type='OpenNebula').first()
+
+            settings = ServiceSettings.objects.filter(type="OpenNebula").first()
             if not settings:
-                return Response({'detail': 'No OpenNebula service settings found.'}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"detail": "No OpenNebula service settings found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             backend = OpenNebulaBackend(settings)
             offerings = backend.list_marketplace_offerings()
             return Response(offerings, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer)},
-    description="Get monitoring data for a VM."
+    description="Get monitoring data for a VM.",
 )
 class OpenNebulaVMMonitoringView(APIView):
     def get(self, request, pk):
@@ -1141,20 +1631,24 @@ class OpenNebulaVMMonitoringView(APIView):
         data = backend.get_vm_monitoring(vm)
         return Response(data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer(many=True))},
-    description="Get monitoring data for all VMs."
+    description="Get monitoring data for all VMs.",
 )
 class OpenNebulaVMPoolMonitoringView(APIView):
     def get(self, request):
         # Optionally filter by user/project
-        backend = OpenNebulaBackend(ServiceSettings.objects.filter(type='OpenNebula').first())
+        backend = OpenNebulaBackend(
+            ServiceSettings.objects.filter(type="OpenNebula").first()
+        )
         data = backend.get_vmpool_monitoring()
         return Response(data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaQuotaSerializer)},
-    description="Get quota/usage for a tenant."
+    description="Get quota/usage for a tenant.",
 )
 class OpenNebulaQuotaView(APIView):
     def get(self, request, tenant_pk):
@@ -1163,6 +1657,7 @@ class OpenNebulaQuotaView(APIView):
         data = backend.get_group_quota(tenant)
         return Response(data, status=status.HTTP_200_OK)
 
+
 class OpenNebulaScheduledActionViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaScheduledAction.objects.all()
     serializer_class = OpenNebulaScheduledActionSerializer
@@ -1170,122 +1665,195 @@ class OpenNebulaScheduledActionViewSet(viewsets.ModelViewSet):
 
 class OpenNebulaTemplatesViewSet(viewsets.ViewSet):
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of VM templates')},
-        description="List available VM templates for deployment."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of VM templates")},
+        description="List available VM templates for deployment.",
     )
     def list(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             templates = client.list_templates()
             # Minimal serialization for wizard
             data = [
-                {'id': t.ID, 'name': t.NAME, 'cpu': getattr(t.TEMPLATE, 'CPU', None), 'memory': getattr(t.TEMPLATE, 'MEMORY', None)}
-                for t in getattr(templates, 'VMTEMPLATE', [])
+                {
+                    "id": t.ID,
+                    "name": t.NAME,
+                    "cpu": getattr(t.TEMPLATE, "CPU", None),
+                    "memory": getattr(t.TEMPLATE, "MEMORY", None),
+                }
+                for t in getattr(templates, "VMTEMPLATE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         parameters=[
-            OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY),
-            OpenApiParameter('id', type=int, required=True, location=OpenApiParameter.PATH)
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                "id", type=int, required=True, location=OpenApiParameter.PATH
+            ),
         ],
-        responses={200: OpenApiResponse(description='Template details')},
-        description="Get details of a specific VM template."
+        responses={200: OpenApiResponse(description="Template details")},
+        description="Get details of a specific VM template.",
     )
     def retrieve(self, request, pk=None):  # TODO: Implentation
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
-            settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
-            #template = client.get_template(pk) - TODO GET TEMPLATE
-            template = "";
+            ServiceSettings.objects.get(pk=service_settings_id)
+            # template = client.get_template(pk) - TODO GET TEMPLATE
+            template = ""
             if not template:
-                return Response({'detail': 'Template not found.'}, status=status.HTTP_404_NOT_FOUND)
-                
+                return Response(
+                    {"detail": "Template not found."}, status=status.HTTP_404_NOT_FOUND
+                )
+
             # Extract template details
             data = {
-                'id': template.ID,
-                'name': template.NAME,
-                'cpu': getattr(template.TEMPLATE, 'CPU', None),
-                'memory': getattr(template.TEMPLATE, 'MEMORY', None),
-                'disk': getattr(template.TEMPLATE, 'DISK', []),
-                'nic': getattr(template.TEMPLATE, 'NIC', []),
-                'template_data': template.TEMPLATE.toxml()
+                "id": template.ID,
+                "name": template.NAME,
+                "cpu": getattr(template.TEMPLATE, "CPU", None),
+                "memory": getattr(template.TEMPLATE, "MEMORY", None),
+                "disk": getattr(template.TEMPLATE, "DISK", []),
+                "nic": getattr(template.TEMPLATE, "NIC", []),
+                "template_data": template.TEMPLATE.toxml(),
             }
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 class OpenNebulaImagesViewSet(viewsets.ViewSet):
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of images')},
-        description="List available images for disk attach or VM creation."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of images")},
+        description="List available images for disk attach or VM creation.",
     )
     def list(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             images = client.list_images()
             data = [
-                {'id': i.ID, 'name': i.NAME, 'size': getattr(i, 'SIZE', None), 'type': getattr(i, 'TYPE', None)}
-                for i in getattr(images, 'IMAGE', [])
+                {
+                    "id": i.ID,
+                    "name": i.NAME,
+                    "size": getattr(i, "SIZE", None),
+                    "type": getattr(i, "TYPE", None),
+                }
+                for i in getattr(images, "IMAGE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         parameters=[
-            OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY),
-            OpenApiParameter('id', type=int, required=True, location=OpenApiParameter.PATH)
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                "id", type=int, required=True, location=OpenApiParameter.PATH
+            ),
         ],
-        responses={200: OpenApiResponse(description='Image details')},
-        description="Get details of a specific image."
+        responses={200: OpenApiResponse(description="Image details")},
+        description="Get details of a specific image.",
     )
     def retrieve(self, request, pk=None):  # TODO: Implentation
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
-            settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
-            #image = client.get_image(pk)
-            image = "";
+            ServiceSettings.objects.get(pk=service_settings_id)
+            # image = client.get_image(pk)
+            image = ""
             if not image:
-                return Response({'detail': 'Image not found.'}, status=status.HTTP_404_NOT_FOUND)
-                
+                return Response(
+                    {"detail": "Image not found."}, status=status.HTTP_404_NOT_FOUND
+                )
+
             # Extract image details
             data = {
-                'id': image.ID,
-                'name': image.NAME,
-                'size': getattr(image, 'SIZE', None),
-                'type': getattr(image, 'TYPE', None),
-                'persistent': getattr(image, 'PERSISTENT', None),
-                'format': getattr(image, 'FORMAT', None),
-                'state': getattr(image, 'STATE', None),
-                'image_data': image.toxml()
+                "id": image.ID,
+                "name": image.NAME,
+                "size": getattr(image, "SIZE", None),
+                "type": getattr(image, "TYPE", None),
+                "persistent": getattr(image, "PERSISTENT", None),
+                "format": getattr(image, "FORMAT", None),
+                "state": getattr(image, "STATE", None),
+                "image_data": image.toxml(),
             }
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
## Summary
- call Celery tasks asynchronously with `.delay()` in both the VM viewset and the wizard endpoints
- rework the VM wizard create endpoint to call the OpenNebula client directly, return the backend VM identifier, and still queue follow-up work
- harden the VM creation task and client utility to cooperate with the new synchronous wizard flow

## Testing
- pytest src/waldur_opennebula/tests/test_views.py *(fails: missing django dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68d2266e98248324acfb0a644ce1f359