### PR TITLE
Handle service settings in OpenNebula tenant creation

### DIFF
--- a/src/waldur_opennebula/backend.py
+++ b/src/waldur_opennebula/backend.py
@@ -1,8 +1,15 @@
+import logging
+
 from waldur_core.structure.backend import ServiceBackend
 from waldur_core.structure.exceptions import ServiceBackendError
+
 from .client import OpenNebulaClient
-from .models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume
-import logging
+from .models import (
+    OpenNebulaNetwork,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +20,9 @@ class OpenNebulaBackendError(ServiceBackendError):
 
 class OpenNebulaBackend(ServiceBackend):
     """Waldur interface to OpenNebula API using pyone."""
-    service_type = 'OpenNebula'
-    
+
+    service_type = "OpenNebula"
+
     def __init__(self, settings):
         self.settings = settings
         self.client = OpenNebulaClient(settings)
@@ -28,10 +36,10 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If ping fails and raise_exception is True
         """
         try:
-            version = self.client.get_version()
+            self.client.get_version()
             return True
         except Exception as e:
-            logger.exception('Failed to ping OpenNebula backend')
+            logger.exception("Failed to ping OpenNebula backend")
             if raise_exception:
                 raise OpenNebulaBackendError(e)
             return False
@@ -48,44 +56,38 @@ class OpenNebulaBackend(ServiceBackend):
                 obj, _ = OpenNebulaTenant.objects.update_or_create(
                     backend_id=str(group.ID),
                     defaults={
-                        'name': group.NAME,
-                        'description': getattr(group, 'DESCRIPTION', ''),
-                        'service_settings': self.settings,
-                        'project': None,  # Project mapping logic can be added
+                        "name": group.NAME,
+                        "description": getattr(group, "DESCRIPTION", ""),
+                        "service_settings": self.settings,
+                        "project": None,  # Project mapping logic can be added
                     },
                 )
                 obj.set_ok()
-                obj.save(update_fields=['state'])
+                obj.save(update_fields=["state"])
             return groups
         except Exception as e:
-            logger.exception('Failed to pull tenants from OpenNebula')
+            logger.exception("Failed to pull tenants from OpenNebula")
             raise OpenNebulaBackendError(e)
 
-    def create_tenant(self, name, description=None):
+    def create_tenant(self, tenant):
         """
         Create a group/project in OpenNebula and a local DB entry.
-        :param name: Tenant name
-        :type name: str
-        :param description: Tenant description
-        :type description: str or None
+        :param tenant: OpenNebulaTenant instance that should be provisioned
+        :type tenant: OpenNebulaTenant
         :return: OpenNebulaTenant instance
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            group_id = self.client.create_group(name, description)
-            group_info = self.client.get_group(group_id)
-            tenant = OpenNebulaTenant.objects.create(
-                backend_id=str(group_id),
-                name=name,
-                description=description or '',
-                service_settings=self.settings,
-                project=None,
-            )
+            group_id = self.client.create_group(tenant.name, tenant.description or "")
+            tenant.backend_id = str(group_id)
+            if tenant.service_settings != self.settings:
+                tenant.service_settings = self.settings
+            tenant.save(update_fields=["backend_id", "service_settings"])
             tenant.set_ok()
-            tenant.save(update_fields=['state'])
+            tenant.save(update_fields=["state"])
             return tenant
         except Exception as e:
-            logger.exception('Failed to create tenant in OpenNebula')
+            logger.exception("Failed to create tenant in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def delete_tenant(self, tenant):
@@ -97,10 +99,10 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             self.client.delete_group(tenant.backend_id)
             tenant.schedule_deleting()
-            tenant.save(update_fields=['state'])
+            tenant.save(update_fields=["state"])
             tenant.delete()
         except Exception as e:
-            logger.exception('Failed to delete tenant in OpenNebula')
+            logger.exception("Failed to delete tenant in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def pull_vms(self, tenant=None):
@@ -116,20 +118,24 @@ class OpenNebulaBackend(ServiceBackend):
                 obj, _ = OpenNebulaVirtualMachine.objects.update_or_create(
                     backend_id=str(vm.ID),
                     defaults={
-                        'name': vm.NAME,
-                        'cpu': int(vm.TEMPLATE.CPU) if hasattr(vm.TEMPLATE, 'CPU') else 1,
-                        'ram': int(vm.TEMPLATE.MEMORY) if hasattr(vm.TEMPLATE, 'MEMORY') else 1024,
-                        'disk': 10,  # Disk size extraction can be improved
-                        'tenant': tenant,
-                        'service_settings': self.settings,
-                        'project': tenant.project if tenant else None,
+                        "name": vm.NAME,
+                        "cpu": int(vm.TEMPLATE.CPU)
+                        if hasattr(vm.TEMPLATE, "CPU")
+                        else 1,
+                        "ram": int(vm.TEMPLATE.MEMORY)
+                        if hasattr(vm.TEMPLATE, "MEMORY")
+                        else 1024,
+                        "disk": 10,  # Disk size extraction can be improved
+                        "tenant": tenant,
+                        "service_settings": self.settings,
+                        "project": tenant.project if tenant else None,
                     },
                 )
                 obj.set_ok()
-                obj.save(update_fields=['state'])
+                obj.save(update_fields=["state"])
             return vms
         except Exception as e:
-            logger.exception('Failed to pull VMs from OpenNebula')
+            logger.exception("Failed to pull VMs from OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def create_vm(self, tenant, name, template_id, cpu=1, ram=1024, disk=10):
@@ -145,9 +151,8 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            extra = {'CPU': cpu, 'MEMORY': ram}
+            extra = {"CPU": cpu, "MEMORY": ram}
             vm_id = self.client.create_vm(template_id, name=name, extra=extra)
-            vm_info = self.client.get_vm(vm_id)
             vm = OpenNebulaVirtualMachine.objects.create(
                 backend_id=str(vm_id),
                 name=name,
@@ -159,10 +164,10 @@ class OpenNebulaBackend(ServiceBackend):
                 project=tenant.project,
             )
             vm.set_ok()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
             return vm
         except Exception as e:
-            logger.exception('Failed to create VM in OpenNebula')
+            logger.exception("Failed to create VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def delete_vm(self, vm):
@@ -174,10 +179,10 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             self.client.delete_vm(vm.backend_id)
             vm.schedule_deleting()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
             vm.delete()
         except Exception as e:
-            logger.exception('Failed to delete VM in OpenNebula')
+            logger.exception("Failed to delete VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def start_vm(self, vm):
@@ -189,9 +194,9 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             self.client.start_vm(vm.backend_id)
             vm.set_ok()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
         except Exception as e:
-            logger.exception('Failed to start VM in OpenNebula')
+            logger.exception("Failed to start VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def stop_vm(self, vm):
@@ -203,9 +208,9 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             self.client.stop_vm(vm.backend_id)
             vm.set_ok()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
         except Exception as e:
-            logger.exception('Failed to stop VM in OpenNebula')
+            logger.exception("Failed to stop VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def pull_volumes(self, tenant=None):
@@ -221,18 +226,18 @@ class OpenNebulaBackend(ServiceBackend):
                 obj, _ = OpenNebulaVolume.objects.update_or_create(
                     backend_id=str(vol.ID),
                     defaults={
-                        'name': vol.NAME,
-                        'description': getattr(vol, 'DESCRIPTION', ''),
-                        'tenant': tenant,
-                        'service_settings': self.settings,
-                        'size': int(getattr(vol, 'SIZE', 0)),
+                        "name": vol.NAME,
+                        "description": getattr(vol, "DESCRIPTION", ""),
+                        "tenant": tenant,
+                        "service_settings": self.settings,
+                        "size": int(getattr(vol, "SIZE", 0)),
                     },
                 )
                 obj.set_ok()
-                obj.save(update_fields=['state'])
+                obj.save(update_fields=["state"])
             return volumes
         except Exception as e:
-            logger.exception('Failed to pull volumes from OpenNebula')
+            logger.exception("Failed to pull volumes from OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def create_volume(self, tenant, name, size, description=None):
@@ -247,20 +252,19 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             vol_id = self.client.create_volume(name, size, description)
-            vol_info = self.client.get_volume(vol_id)
             volume = OpenNebulaVolume.objects.create(
                 backend_id=str(vol_id),
                 name=name,
-                description=description or '',
+                description=description or "",
                 tenant=tenant,
                 service_settings=self.settings,
                 size=size,
             )
             volume.set_ok()
-            volume.save(update_fields=['state'])
+            volume.save(update_fields=["state"])
             return volume
         except Exception as e:
-            logger.exception('Failed to create volume in OpenNebula')
+            logger.exception("Failed to create volume in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def delete_volume(self, volume):
@@ -272,16 +276,16 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             self.client.delete_volume(volume.backend_id)
             volume.schedule_deleting()
-            volume.save(update_fields=['state'])
+            volume.save(update_fields=["state"])
             volume.delete()
         except Exception as e:
-            logger.exception('Failed to delete volume in OpenNebula')
+            logger.exception("Failed to delete volume in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def set_tenant_quota(self, tenant, quota_template):
         """
         Set quota limits for a tenant (group) in OpenNebula.
-        
+
         :param tenant: OpenNebulaTenant instance
         :type tenant: OpenNebulaTenant
         :param quota_template: Quota template with limits to set
@@ -292,13 +296,13 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             return self.client.set_group_quota(int(tenant.backend_id), quota_template)
         except Exception as e:
-            logger.exception('Failed to set tenant quota in OpenNebula')
+            logger.exception("Failed to set tenant quota in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def get_tenant_quota(self, tenant):
         """
         Get current quota limits for a tenant (group) from OpenNebula.
-        
+
         :param tenant: OpenNebulaTenant instance
         :type tenant: OpenNebulaTenant
         :return: Quota information dictionary
@@ -307,13 +311,13 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             return self.client.get_group_quota(int(tenant.backend_id))
         except Exception as e:
-            logger.exception('Failed to get tenant quota from OpenNebula')
+            logger.exception("Failed to get tenant quota from OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def reboot_vm(self, vm):
         """
         Reboot a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :return: Success status
@@ -323,16 +327,16 @@ class OpenNebulaBackend(ServiceBackend):
             result = self.client.reboot_vm(vm.backend_id)
             # Update VM state in the database
             vm.set_ok()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
             return result
         except Exception as e:
-            logger.exception('Failed to reboot VM in OpenNebula')
+            logger.exception("Failed to reboot VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def resize_vm(self, vm, cpu=None, ram=None):
         """
         Resize a virtual machine's CPU and/or RAM.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param cpu: New CPU value (number of vCPUs)
@@ -344,24 +348,24 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.resize_vm(vm.backend_id, cpu=cpu, ram=ram)
-            
+
             # Update VM resource values in the database
             if cpu is not None:
                 vm.cpu = cpu
             if ram is not None:
                 vm.ram = ram
-                
+
             vm.set_ok()
-            vm.save(update_fields=['cpu', 'ram', 'state'])
+            vm.save(update_fields=["cpu", "ram", "state"])
             return result
         except Exception as e:
-            logger.exception('Failed to resize VM in OpenNebula')
+            logger.exception("Failed to resize VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def attach_disk(self, vm, volume):
         """
         Attach a disk volume to a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param volume: OpenNebulaVolume instance to attach
@@ -372,31 +376,31 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             # Create a disk template with the volume ID
             disk_template = {
-                'IMAGE_ID': volume.backend_id,
-                'DEV_PREFIX': 'vd',  # This is a typical device prefix, but might need adjustment
+                "IMAGE_ID": volume.backend_id,
+                "DEV_PREFIX": "vd",  # This is a typical device prefix, but might need adjustment
             }
-            
+
             result = self.client.attach_disk(vm.backend_id, disk_template)
-            
+
             # Update the relationship between VM and volume
             # Note: You might need a separate model for VM-volume relationships
             # or add a field to the volume model to track attachment status
-            
+
             # Update states
             vm.set_ok()
-            vm.save(update_fields=['state'])
+            vm.save(update_fields=["state"])
             volume.set_ok()
-            volume.save(update_fields=['state'])
-            
+            volume.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to attach disk to VM in OpenNebula')
+            logger.exception("Failed to attach disk to VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def detach_disk(self, vm, disk_id):
         """
         Detach a disk from a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk to detach
@@ -406,23 +410,23 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.detach_disk(vm.backend_id, disk_id)
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # If you have a relationship model or field for volume attachment,
             # you would update it here
-            
+
             return result
         except Exception as e:
-            logger.exception('Failed to detach disk from VM in OpenNebula')
+            logger.exception("Failed to detach disk from VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def snapshot_vm(self, vm, name):
         """
         Create a snapshot of a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param name: Name for the snapshot
@@ -432,23 +436,23 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             snapshot_id = self.client.snapshot_vm(vm.backend_id, name)
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # You might want to create a DB entry for the snapshot
             # if you have a model for VM snapshots
-            
+
             return snapshot_id
         except Exception as e:
-            logger.exception('Failed to create VM snapshot in OpenNebula')
+            logger.exception("Failed to create VM snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def restore_vm_snapshot(self, vm, snapshot_id):
         """
         Restore a virtual machine from a snapshot.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param snapshot_id: ID of the snapshot to restore
@@ -458,20 +462,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.restore_vm_snapshot(vm.backend_id, snapshot_id)
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to restore VM snapshot in OpenNebula')
+            logger.exception("Failed to restore VM snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def get_console(self, vm):
         """
         Get console connection information for a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :return: Console connection information
@@ -480,13 +484,13 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             return self.client.get_console(vm.backend_id)
         except Exception as e:
-            logger.exception('Failed to get VM console in OpenNebula')
+            logger.exception("Failed to get VM console in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def update_network(self, network, template):
         """
         Update a virtual network's configuration.
-        
+
         :param network: OpenNebulaNetwork instance
         :type network: OpenNebulaNetwork
         :param template: Network configuration template
@@ -496,20 +500,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.update_network(network.backend_id, template)
-            
+
             # Update network state
             network.set_ok()
-            network.save(update_fields=['state'])
-            
+            network.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to update network in OpenNebula')
+            logger.exception("Failed to update network in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def add_ar(self, network, ar_template):
         """
         Add an address range to a virtual network.
-        
+
         :param network: OpenNebulaNetwork instance
         :type network: OpenNebulaNetwork
         :param ar_template: Address range template
@@ -519,20 +523,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.add_ar(network.backend_id, ar_template)
-            
+
             # Update network state
             network.set_ok()
-            network.save(update_fields=['state'])
-            
+            network.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to add address range to network in OpenNebula')
+            logger.exception("Failed to add address range to network in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def rm_ar(self, network, ar_id, force=False):
         """
         Remove an address range from a virtual network.
-        
+
         :param network: OpenNebulaNetwork instance
         :type network: OpenNebulaNetwork
         :param ar_id: Address range ID to remove
@@ -544,20 +548,22 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.rm_ar(network.backend_id, ar_id, force)
-            
+
             # Update network state
             network.set_ok()
-            network.save(update_fields=['state'])
-            
+            network.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to remove address range from network in OpenNebula')
+            logger.exception(
+                "Failed to remove address range from network in OpenNebula"
+            )
             raise OpenNebulaBackendError(e)
 
     def update_ar(self, network, ar_template):
         """
         Update an address range in a virtual network.
-        
+
         :param network: OpenNebulaNetwork instance
         :type network: OpenNebulaNetwork
         :param ar_template: Address range template with updates
@@ -567,20 +573,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.update_ar(network.backend_id, ar_template)
-            
+
             # Update network state
             network.set_ok()
-            network.save(update_fields=['state'])
-            
+            network.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to update address range in network in OpenNebula')
+            logger.exception("Failed to update address range in network in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def reserve_ar(self, network, reservation_template):
         """
         Reserve addresses from a virtual network.
-        
+
         :param network: OpenNebulaNetwork instance
         :type network: OpenNebulaNetwork
         :param reservation_template: Reservation configuration template
@@ -590,20 +596,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.reserve_ar(network.backend_id, reservation_template)
-            
+
             # Update network state
             network.set_ok()
-            network.save(update_fields=['state'])
-            
+            network.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to reserve address range in OpenNebula')
+            logger.exception("Failed to reserve address range in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def create_disk_snapshot(self, vm, disk_id, description=None):
         """
         Create a new snapshot of a disk image.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk to snapshot
@@ -614,24 +620,26 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            snapshot_id = self.client.create_disk_snapshot(vm.backend_id, disk_id, description)
-            
+            snapshot_id = self.client.create_disk_snapshot(
+                vm.backend_id, disk_id, description
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # You might want to create a DB entry for the disk snapshot
             # if you have a model for disk snapshots
-            
+
             return snapshot_id
         except Exception as e:
-            logger.exception('Failed to create disk snapshot in OpenNebula')
+            logger.exception("Failed to create disk snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def delete_disk_snapshot(self, vm, disk_id, snapshot_id):
         """
         Delete a disk snapshot.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk
@@ -642,23 +650,25 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            result = self.client.delete_disk_snapshot(vm.backend_id, disk_id, snapshot_id)
-            
+            result = self.client.delete_disk_snapshot(
+                vm.backend_id, disk_id, snapshot_id
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # If you have a disk snapshot model, you would delete the DB entry here
-            
+
             return result
         except Exception as e:
-            logger.exception('Failed to delete disk snapshot in OpenNebula')
+            logger.exception("Failed to delete disk snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def revert_disk_snapshot(self, vm, disk_id, snapshot_id):
         """
         Revert disk state to a previously taken snapshot.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk
@@ -669,21 +679,23 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            result = self.client.revert_disk_snapshot(vm.backend_id, disk_id, snapshot_id)
-            
+            result = self.client.revert_disk_snapshot(
+                vm.backend_id, disk_id, snapshot_id
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to revert disk snapshot in OpenNebula')
+            logger.exception("Failed to revert disk snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def rename_disk_snapshot(self, vm, disk_id, snapshot_id, new_name):
         """
         Rename a disk snapshot.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk
@@ -696,23 +708,25 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            result = self.client.rename_disk_snapshot(vm.backend_id, disk_id, snapshot_id, new_name)
-            
+            result = self.client.rename_disk_snapshot(
+                vm.backend_id, disk_id, snapshot_id, new_name
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # If you have a disk snapshot model, you would update the name here
-            
+
             return result
         except Exception as e:
-            logger.exception('Failed to rename disk snapshot in OpenNebula')
+            logger.exception("Failed to rename disk snapshot in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def resize_disk(self, vm, disk_id, size):
         """
         Resize a disk attached to a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk to resize
@@ -724,22 +738,24 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.resize_disk(vm.backend_id, disk_id, size)
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # If you track disk sizes in your database, you would update that here
-            
+
             return result
         except Exception as e:
-            logger.exception('Failed to resize disk in OpenNebula')
+            logger.exception("Failed to resize disk in OpenNebula")
             raise OpenNebulaBackendError(e)
 
-    def save_disk_as_image(self, vm, disk_id, image_name, image_type="", snapshot_id=-1):
+    def save_disk_as_image(
+        self, vm, disk_id, image_name, image_type="", snapshot_id=-1
+    ):
         """
         Save a disk as a new image in OpenNebula.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param disk_id: ID of the disk to save
@@ -754,18 +770,20 @@ class OpenNebulaBackend(ServiceBackend):
         :raises OpenNebulaBackendError: If the operation fails
         """
         try:
-            image_id = self.client.save_disk_as_image(vm.backend_id, disk_id, image_name, image_type, snapshot_id)
-            
+            image_id = self.client.save_disk_as_image(
+                vm.backend_id, disk_id, image_name, image_type, snapshot_id
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             # You might want to create a new volume entry in the DB for the new image
             # This would depend on your application's logic for handling newly created images
-            
+
             return image_id
         except Exception as e:
-            logger.exception('Failed to save disk as image in OpenNebula')
+            logger.exception("Failed to save disk as image in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def pull_networks(self, tenant=None):
@@ -775,41 +793,45 @@ class OpenNebulaBackend(ServiceBackend):
             obj, _ = OpenNebulaNetwork.objects.update_or_create(
                 backend_id=str(net.ID),
                 defaults={
-                    'name': net.NAME,
-                    'description': getattr(net, 'DESCRIPTION', ''),
-                    'tenant': tenant,
-                    'service_settings': self.settings,
+                    "name": net.NAME,
+                    "description": getattr(net, "DESCRIPTION", ""),
+                    "tenant": tenant,
+                    "service_settings": self.settings,
                 },
             )
             obj.set_ok()
-            obj.save(update_fields=['state'])
+            obj.save(update_fields=["state"])
         return networks
 
     def create_network(self, tenant, name, description=None):
         # Create a virtual network in OpenNebula and a local DB entry
         net_id = self.client.create_network(name, description)
-        net_info = self.client.get_network(net_id)
+        self.client.get_network(net_id)
         network = OpenNebulaNetwork.objects.create(
             backend_id=str(net_id),
             name=name,
-            description=description or '',
+            description=description or "",
             tenant=tenant,
             service_settings=self.settings,
         )
         network.set_ok()
-        network.save(update_fields=['state'])
+        network.save(update_fields=["state"])
         return network
 
     def delete_network(self, network):
         # Delete a virtual network in OpenNebula and remove the local DB entry
         self.client.delete_network(network.backend_id)
         network.schedule_deleting()
-        network.save(update_fields=['state'])
+        network.save(update_fields=["state"])
         network.delete()
 
-    def migrate_vm(self, vm, host_id, live=True, enforce=False, ds_id=None, migration_type=0):
+    def migrate_vm(
+        self, vm, host_id, live=True, enforce=False, ds_id=None, migration_type=0
+    ):
         """Migrate a VM to a target host."""
-        return self.client.migrate_vm(vm.backend_id, host_id, live, enforce, ds_id, migration_type)
+        return self.client.migrate_vm(
+            vm.backend_id, host_id, live, enforce, ds_id, migration_type
+        )
 
     def backup_vm(self, vm, ds_id, reset: bool = False):
         """
@@ -823,7 +845,7 @@ class OpenNebulaBackend(ServiceBackend):
             safe_reset = reset if reset is not None else False
             return self.client.backup_vm(vm.backend_id, ds_id, bool(safe_reset))
         except Exception as e:
-            logger.exception('Failed to backup VM in OpenNebula')
+            logger.exception("Failed to backup VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def backup_cancel(self, vm):
@@ -840,23 +862,23 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             if vm is None:
-                raise OpenNebulaBackendError('VM instance is required for restore_vm.')
+                raise OpenNebulaBackendError("VM instance is required for restore_vm.")
             return self.client.restore_vm(vm.backend_id, backup_id, in_place)
         except Exception as e:
-            logger.exception('Failed to restore VM in OpenNebula')
+            logger.exception("Failed to restore VM in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def list_snapshots(self, vm):
         client = OpenNebulaClient(vm.service_settings)
         info = client.get_vm(vm.backend_id)
         # Assume info.SNAPSHOTS.SNAPSHOT is a list of snapshot objects
-        snapshots = getattr(getattr(info, 'SNAPSHOTS', None), 'SNAPSHOT', [])
+        snapshots = getattr(getattr(info, "SNAPSHOTS", None), "SNAPSHOT", [])
         return [
             {
-                'id': s.ID,
-                'name': s.NAME,
-                'date': getattr(s, 'DATE', None),
-                'active': getattr(s, 'ACTIVE', None),
+                "id": s.ID,
+                "name": s.NAME,
+                "date": getattr(s, "DATE", None),
+                "active": getattr(s, "ACTIVE", None),
             }
             for s in snapshots
         ]
@@ -870,14 +892,14 @@ class OpenNebulaBackend(ServiceBackend):
         # This is a placeholder; actual implementation depends on OpenNebula backup API
         # For now, return a list of backup dicts
         info = client.get_vm(vm.backend_id)
-        backups = getattr(getattr(info, 'BACKUPS', None), 'BACKUP', [])
+        backups = getattr(getattr(info, "BACKUPS", None), "BACKUP", [])
         return [
             {
-                'id': b.ID,
-                'name': b.NAME,
-                'date': getattr(b, 'DATE', None),
-                'type': getattr(b, 'TYPE', None),
-                'state': getattr(b, 'STATE', None),
+                "id": b.ID,
+                "name": b.NAME,
+                "date": getattr(b, "DATE", None),
+                "type": getattr(b, "TYPE", None),
+                "state": getattr(b, "STATE", None),
             }
             for b in backups
         ]
@@ -901,34 +923,37 @@ class OpenNebulaBackend(ServiceBackend):
                 return self.client.restore_vm(vm.backend_id, backup_id, in_place=True)
             elif not in_place and new_vm_name:
                 # OpenNebulaClient.restore_vm does not support new_vm_name; not implemented
-                raise NotImplementedError('Restoring backup as a new VM with a custom name is not supported by OpenNebulaClient.restore_vm.')
+                raise NotImplementedError(
+                    "Restoring backup as a new VM with a custom name is not supported by OpenNebulaClient.restore_vm."
+                )
             else:
-                raise OpenNebulaBackendError('Invalid parameters for restore_backup: either vm and in_place, or new_vm_name must be provided.')
+                raise OpenNebulaBackendError(
+                    "Invalid parameters for restore_backup: either vm and in_place, or new_vm_name must be provided."
+                )
         except Exception as e:
-            logger.exception('Failed to restore backup in OpenNebula')
+            logger.exception("Failed to restore backup in OpenNebula")
             raise OpenNebulaBackendError(e)
 
     def list_marketplace_offerings(self):
         client = OpenNebulaClient(self.settings)
         templates = client.list_templates()
-        images = client.list_images()
         # Aggregate templates/images into offering dicts
         offerings = []
-        for t in getattr(templates, 'VMTEMPLATE', []):
+        for t in getattr(templates, "VMTEMPLATE", []):
             offering = {
-                'id': t.ID,
-                'name': t.NAME,
-                'description': getattr(t, 'DESCRIPTION', ''),
-                'template_id': t.ID,
-                'cpu': getattr(t.TEMPLATE, 'CPU', None),
-                'ram': getattr(t.TEMPLATE, 'MEMORY', None),
-                'disk': getattr(t.TEMPLATE, 'DISK_SIZE', None),
-                'category': getattr(t, 'CATEGORY', ''),
-                'extra': {},
+                "id": t.ID,
+                "name": t.NAME,
+                "description": getattr(t, "DESCRIPTION", ""),
+                "template_id": t.ID,
+                "cpu": getattr(t.TEMPLATE, "CPU", None),
+                "ram": getattr(t.TEMPLATE, "MEMORY", None),
+                "disk": getattr(t.TEMPLATE, "DISK_SIZE", None),
+                "category": getattr(t, "CATEGORY", ""),
+                "extra": {},
             }
             # Optionally, link to an image
-            if hasattr(t.TEMPLATE, 'IMAGE_ID'):
-                offering['image_id'] = t.TEMPLATE.IMAGE_ID
+            if hasattr(t.TEMPLATE, "IMAGE_ID"):
+                offering["image_id"] = t.TEMPLATE.IMAGE_ID
             offerings.append(offering)
         return offerings
 
@@ -942,14 +967,14 @@ class OpenNebulaBackend(ServiceBackend):
 
     def get_group_quota(self, tenant):
         info = self.client.get_group(tenant.backend_id)
-        return getattr(info, 'QUOTAS', {})
+        return getattr(info, "QUOTAS", {})
 
     # Add methods for tenant and VM management, following OpenStack backend as a guide
-    
+
     def attach_nic(self, vm, network_id, ip=None, model=None):
         """
         Attach a new network interface to a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param network_id: ID of the network to connect to
@@ -963,29 +988,29 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             # Build NIC template
-            nic_template = {'NETWORK_ID': int(network_id)}
-            
+            nic_template = {"NETWORK_ID": int(network_id)}
+
             # Add optional parameters if provided
             if ip:
-                nic_template['IP'] = ip
+                nic_template["IP"] = ip
             if model:
-                nic_template['MODEL'] = model
-                
+                nic_template["MODEL"] = model
+
             result = self.client.attach_nic(int(vm.backend_id), nic_template)
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to attach NIC to VM in OpenNebula')
+            logger.exception("Failed to attach NIC to VM in OpenNebula")
             raise OpenNebulaBackendError(f"Failed to attach NIC: {str(e)}")
-    
+
     def detach_nic(self, vm, nic_id):
         """
         Detach a network interface from a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param nic_id: ID of the NIC to detach
@@ -995,20 +1020,20 @@ class OpenNebulaBackend(ServiceBackend):
         """
         try:
             result = self.client.detach_nic(int(vm.backend_id), int(nic_id))
-            
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to detach NIC from VM in OpenNebula')
+            logger.exception("Failed to detach NIC from VM in OpenNebula")
             raise OpenNebulaBackendError(f"Failed to detach NIC: {str(e)}")
-    
+
     def update_nic(self, vm, nic_id, **kwargs):
         """
         Update a network interface on a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :param nic_id: ID of the NIC to update
@@ -1020,43 +1045,56 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             # Build NIC template with provided parameters
             nic_template = {}
-            
+
             # Map common parameters to OpenNebula NIC attributes
-            if 'security_groups' in kwargs:
-                nic_template['SECURITY_GROUPS'] = kwargs['security_groups']
-            if 'network_qos' in kwargs:
-                nic_template['INBOUND_AVG_BW'] = kwargs['network_qos'].get('inbound_avg_bw')
-                nic_template['INBOUND_PEAK_BW'] = kwargs['network_qos'].get('inbound_peak_bw')
-                nic_template['OUTBOUND_AVG_BW'] = kwargs['network_qos'].get('outbound_avg_bw')
-                nic_template['OUTBOUND_PEAK_BW'] = kwargs['network_qos'].get('outbound_peak_bw')
-            if 'model' in kwargs:
-                nic_template['MODEL'] = kwargs['model']
-            
+            if "security_groups" in kwargs:
+                nic_template["SECURITY_GROUPS"] = kwargs["security_groups"]
+            if "network_qos" in kwargs:
+                nic_template["INBOUND_AVG_BW"] = kwargs["network_qos"].get(
+                    "inbound_avg_bw"
+                )
+                nic_template["INBOUND_PEAK_BW"] = kwargs["network_qos"].get(
+                    "inbound_peak_bw"
+                )
+                nic_template["OUTBOUND_AVG_BW"] = kwargs["network_qos"].get(
+                    "outbound_avg_bw"
+                )
+                nic_template["OUTBOUND_PEAK_BW"] = kwargs["network_qos"].get(
+                    "outbound_peak_bw"
+                )
+            if "model" in kwargs:
+                nic_template["MODEL"] = kwargs["model"]
+
             # Add any other parameters directly
             for key, value in kwargs.items():
-                if key not in ['security_groups', 'network_qos', 'model'] and value is not None:
+                if (
+                    key not in ["security_groups", "network_qos", "model"]
+                    and value is not None
+                ):
                     nic_template[key.upper()] = value
-            
+
             # Only proceed if we have parameters to update
             if not nic_template:
-                logger.warning('No parameters provided for NIC update')
+                logger.warning("No parameters provided for NIC update")
                 return False
-                
-            result = self.client.update_nic(int(vm.backend_id), int(nic_id), nic_template)
-            
+
+            result = self.client.update_nic(
+                int(vm.backend_id), int(nic_id), nic_template
+            )
+
             # Update VM state
             vm.set_ok()
-            vm.save(update_fields=['state'])
-            
+            vm.save(update_fields=["state"])
+
             return result
         except Exception as e:
-            logger.exception('Failed to update NIC on VM in OpenNebula')
+            logger.exception("Failed to update NIC on VM in OpenNebula")
             raise OpenNebulaBackendError(f"Failed to update NIC: {str(e)}")
-    
+
     def list_nics(self, vm):
         """
         List all network interfaces attached to a virtual machine.
-        
+
         :param vm: OpenNebulaVirtualMachine instance
         :type vm: OpenNebulaVirtualMachine
         :return: List of NIC information dictionaries
@@ -1065,35 +1103,43 @@ class OpenNebulaBackend(ServiceBackend):
         try:
             # Get the VM info which contains NIC data
             vm_info = self.client.get_vm(int(vm.backend_id))
-            
+
             # Extract NIC information
             nics = []
-            if hasattr(vm_info.TEMPLATE, 'NIC'):
+            if hasattr(vm_info.TEMPLATE, "NIC"):
                 # Handle both single NIC and multiple NICs
                 nic_data = vm_info.TEMPLATE.NIC
                 if isinstance(nic_data, list):
                     for nic in nic_data:
-                        nics.append({
-                            'id': getattr(nic, 'NIC_ID', None),
-                            'network_id': getattr(nic, 'NETWORK_ID', None),
-                            'network': getattr(nic, 'NETWORK', None),
-                            'mac': getattr(nic, 'MAC', None),
-                            'ip': getattr(nic, 'IP', None),
-                            'model': getattr(nic, 'MODEL', None),
-                            'security_groups': getattr(nic, 'SECURITY_GROUPS', None),
-                        })
+                        nics.append(
+                            {
+                                "id": getattr(nic, "NIC_ID", None),
+                                "network_id": getattr(nic, "NETWORK_ID", None),
+                                "network": getattr(nic, "NETWORK", None),
+                                "mac": getattr(nic, "MAC", None),
+                                "ip": getattr(nic, "IP", None),
+                                "model": getattr(nic, "MODEL", None),
+                                "security_groups": getattr(
+                                    nic, "SECURITY_GROUPS", None
+                                ),
+                            }
+                        )
                 else:
-                    nics.append({
-                        'id': getattr(nic_data, 'NIC_ID', None),
-                        'network_id': getattr(nic_data, 'NETWORK_ID', None),
-                        'network': getattr(nic_data, 'NETWORK', None),
-                        'mac': getattr(nic_data, 'MAC', None),
-                        'ip': getattr(nic_data, 'IP', None),
-                        'model': getattr(nic_data, 'MODEL', None),
-                        'security_groups': getattr(nic_data, 'SECURITY_GROUPS', None),
-                    })
-            
+                    nics.append(
+                        {
+                            "id": getattr(nic_data, "NIC_ID", None),
+                            "network_id": getattr(nic_data, "NETWORK_ID", None),
+                            "network": getattr(nic_data, "NETWORK", None),
+                            "mac": getattr(nic_data, "MAC", None),
+                            "ip": getattr(nic_data, "IP", None),
+                            "model": getattr(nic_data, "MODEL", None),
+                            "security_groups": getattr(
+                                nic_data, "SECURITY_GROUPS", None
+                            ),
+                        }
+                    )
+
             return nics
         except Exception as e:
-            logger.exception('Failed to list NICs for VM in OpenNebula')
+            logger.exception("Failed to list NICs for VM in OpenNebula")
             raise OpenNebulaBackendError(f"Failed to list NICs: {str(e)}")

--- a/src/waldur_opennebula/serializers.py
+++ b/src/waldur_opennebula/serializers.py
@@ -1,17 +1,22 @@
-from rest_framework import serializers
 from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
 
 from waldur_core.structure import serializers as structure_serializers
 
-from .models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume, ServiceSettings, OpenNebulaScheduledAction
+from .models import (
+    OpenNebulaNetwork,
+    OpenNebulaScheduledAction,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+    Project,
+    ServiceSettings,
+)
+
 
 class OpenNebulaServiceSerializer(structure_serializers.ServiceOptionsSerializer):
     class Meta:
-        secret_fields = (
-            "backend_url",
-            "username",
-            "password"
-        )
+        secret_fields = ("backend_url", "username", "password")
 
     backend_url = serializers.CharField(
         label=_("OpenNebula API Endpoint"),
@@ -24,17 +29,66 @@ class OpenNebulaServiceSerializer(structure_serializers.ServiceOptionsSerializer
     password = serializers.CharField(
         label=_("OpenNebula Admin Password"),
     )
-    
+
+
 class OpenNebulaTenantSerializer(serializers.ModelSerializer):
     class Meta:
         model = OpenNebulaTenant
-        fields = '__all__'
+        fields = "__all__"
 
 
-class OpenNebulaTenantCreateSerializer(serializers.ModelSerializer):
+class OpenNebulaTenantCreateSerializer(
+    structure_serializers.PermissionFieldFilteringMixin, serializers.ModelSerializer
+):
+    service_settings = serializers.PrimaryKeyRelatedField(
+        queryset=ServiceSettings.objects.all()
+    )
+    project = serializers.PrimaryKeyRelatedField(queryset=Project.objects.all())
+
     class Meta:
         model = OpenNebulaTenant
-        fields = ['name', 'description']
+        fields = ["name", "description", "service_settings", "project"]
+
+    def get_filtered_field_names(self):
+        return ("service_settings", "project")
+
+    def get_fields(self):
+        fields = super().get_fields()
+        service_settings_field = fields.get("service_settings")
+        if service_settings_field and not service_settings_field.read_only:
+            service_settings_field.queryset = service_settings_field.queryset.filter(
+                type="OpenNebula"
+            )
+        return fields
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        service_settings = attrs["service_settings"]
+        project = attrs["project"]
+
+        if service_settings.type != "OpenNebula":
+            raise serializers.ValidationError(
+                {
+                    "service_settings": _(
+                        "Selected service settings must belong to the OpenNebula plugin."
+                    )
+                }
+            )
+
+        if (
+            not service_settings.shared
+            and service_settings.customer
+            and service_settings.customer != project.customer
+        ):
+            raise serializers.ValidationError(
+                {
+                    "service_settings": _(
+                        "Service settings must belong to the same organization as the project."
+                    )
+                }
+            )
+
+        return attrs
 
 
 class OpenNebulaVirtualMachineSerializer(serializers.ModelSerializer):
@@ -44,7 +98,7 @@ class OpenNebulaVirtualMachineSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OpenNebulaVirtualMachine
-        fields = '__all__'
+        fields = "__all__"
 
 
 class OpenNebulaNetworkSerializer(serializers.ModelSerializer):
@@ -53,7 +107,7 @@ class OpenNebulaNetworkSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OpenNebulaNetwork
-        fields = '__all__'
+        fields = "__all__"
 
 
 class OpenNebulaVolumeSerializer(serializers.ModelSerializer):
@@ -63,25 +117,29 @@ class OpenNebulaVolumeSerializer(serializers.ModelSerializer):
     class Meta:
         model = OpenNebulaVolume
         fields = (
-            'uuid',
-            'name',
-            'description',
-            'tenant',
-            'service_settings',
-            'backend_id',
-            'size',
-            'created',
-            'modified',
-            'progress',
-            'error_message',
+            "uuid",
+            "name",
+            "description",
+            "tenant",
+            "service_settings",
+            "backend_id",
+            "size",
+            "created",
+            "modified",
+            "progress",
+            "error_message",
         )
 
 
 class OpenNebulaVMCreateSerializer(serializers.Serializer):
-    service_settings = serializers.PrimaryKeyRelatedField(queryset=ServiceSettings.objects.all())
+    service_settings = serializers.PrimaryKeyRelatedField(
+        queryset=ServiceSettings.objects.all()
+    )
     template_id = serializers.IntegerField()
     name = serializers.CharField(max_length=128)
-    networks = serializers.ListField(child=serializers.IntegerField(), allow_empty=False)
+    networks = serializers.ListField(
+        child=serializers.IntegerField(), allow_empty=False
+    )
     cpu = serializers.FloatField(required=False)
     ram = serializers.IntegerField(required=False)
     disk = serializers.IntegerField(required=False)
@@ -91,19 +149,27 @@ class OpenNebulaVMCreateSerializer(serializers.Serializer):
 
     def validate(self, attrs):
         # Ensure required fields are present
-        if not attrs.get('service_settings'):
-            raise serializers.ValidationError({'service_settings': 'This field is required.'})
-        if not attrs.get('template_id'):
-            raise serializers.ValidationError({'template_id': 'This field is required.'})
-        if not attrs.get('name'):
-            raise serializers.ValidationError({'name': 'This field is required.'})
-        if not attrs.get('networks'):
-            raise serializers.ValidationError({'networks': 'At least one network must be selected.'})
+        if not attrs.get("service_settings"):
+            raise serializers.ValidationError(
+                {"service_settings": "This field is required."}
+            )
+        if not attrs.get("template_id"):
+            raise serializers.ValidationError(
+                {"template_id": "This field is required."}
+            )
+        if not attrs.get("name"):
+            raise serializers.ValidationError({"name": "This field is required."})
+        if not attrs.get("networks"):
+            raise serializers.ValidationError(
+                {"networks": "At least one network must be selected."}
+            )
         return attrs
 
 
 class OpenNebulaVMMigrateSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     host_id = serializers.IntegerField()
     live = serializers.BooleanField(default=True)
     enforce = serializers.BooleanField(default=False)
@@ -112,7 +178,9 @@ class OpenNebulaVMMigrateSerializer(serializers.Serializer):
 
 
 class OpenNebulaDiskAttachSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     image_id = serializers.IntegerField()
     size = serializers.IntegerField(required=False)
     type = serializers.CharField(required=False, allow_blank=True)
@@ -120,13 +188,17 @@ class OpenNebulaDiskAttachSerializer(serializers.Serializer):
 
 
 class OpenNebulaDiskResizeSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     disk_id = serializers.IntegerField()
     size = serializers.IntegerField()
 
 
 class OpenNebulaDiskSaveAsSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     disk_id = serializers.IntegerField()
     image_name = serializers.CharField()
     image_type = serializers.CharField(required=False, allow_blank=True)
@@ -134,39 +206,53 @@ class OpenNebulaDiskSaveAsSerializer(serializers.Serializer):
 
 
 class OpenNebulaVMSnapshotSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     name = serializers.CharField(max_length=128)
 
 
 class OpenNebulaVMListSnapshotsSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
 
 
 class OpenNebulaBackupCreateSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     name = serializers.CharField(max_length=128)
     description = serializers.CharField(required=False, allow_blank=True)
 
 
 class OpenNebulaBackupListSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
 
 
 class OpenNebulaRestoreBackupSerializer(serializers.Serializer):
     backup_id = serializers.CharField()
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all(), required=False)
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all(), required=False
+    )
     in_place = serializers.BooleanField(default=True)
     new_vm_name = serializers.CharField(required=False, allow_blank=True)
 
 
 class OpenNebulaFloatingIPAssignSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     network_id = serializers.IntegerField()
     ip_address = serializers.CharField(required=False, allow_blank=True)
 
 
 class OpenNebulaFloatingIPReleaseSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     ip_address = serializers.CharField()
 
 
@@ -203,32 +289,57 @@ class OpenNebulaQuotaSerializer(serializers.Serializer):
 class OpenNebulaScheduledActionSerializer(serializers.ModelSerializer):
     class Meta:
         model = OpenNebulaScheduledAction
-        fields = '__all__'
+        fields = "__all__"
 
 
 class OpenNebulaNetworkAttachSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     network_id = serializers.IntegerField()
-    ip_address = serializers.CharField(required=False, allow_blank=True, allow_null=True)
-    model = serializers.CharField(required=False, allow_blank=True, allow_null=True, 
-                                 help_text="Network card model, e.g., 'virtio'")
+    ip_address = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True
+    )
+    model = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Network card model, e.g., 'virtio'",
+    )
 
 
 class OpenNebulaNetworkReleaseSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     nic_id = serializers.IntegerField(help_text="ID of the network interface to detach")
 
 
 class OpenNebulaNetworkUpdateSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )
     nic_id = serializers.IntegerField(help_text="ID of the network interface to update")
-    security_groups = serializers.CharField(required=False, allow_blank=True, allow_null=True,
-                                          help_text="Security groups to apply to the interface")
-    network_qos = serializers.DictField(required=False, allow_null=True,
-                                      help_text="Quality of Service settings for the network interface")
-    model = serializers.CharField(required=False, allow_blank=True, allow_null=True,
-                                help_text="Network card model, e.g., 'virtio'")
+    security_groups = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Security groups to apply to the interface",
+    )
+    network_qos = serializers.DictField(
+        required=False,
+        allow_null=True,
+        help_text="Quality of Service settings for the network interface",
+    )
+    model = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        help_text="Network card model, e.g., 'virtio'",
+    )
 
 
 class OpenNebulaNetworkListSerializer(serializers.Serializer):
-    vm = serializers.PrimaryKeyRelatedField(queryset=OpenNebulaVirtualMachine.objects.all())
+    vm = serializers.PrimaryKeyRelatedField(
+        queryset=OpenNebulaVirtualMachine.objects.all()
+    )

--- a/src/waldur_opennebula/tasks.py
+++ b/src/waldur_opennebula/tasks.py
@@ -1,47 +1,65 @@
-# Place for OpenNebula Celery tasks 
-from celery import shared_task
-from waldur_opennebula.models import OpenNebulaVirtualMachine, OpenNebulaTenant, OpenNebulaVolume
-from waldur_opennebula.backend import OpenNebulaBackend
-from waldur_core.structure.models import ServiceSettings
-from .client import OpenNebulaClient
-from django.utils import timezone
+# Place for OpenNebula Celery tasks
 from datetime import timedelta
+
+from celery import shared_task
+from django.utils import timezone
+
+from waldur_core.structure.models import ServiceSettings
+from waldur_opennebula.backend import OpenNebulaBackend
+from waldur_opennebula.models import (
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+)
+
+from .client import OpenNebulaClient
 from .models import OpenNebulaScheduledAction
 
 
 @shared_task
-def create_vm_task(vm_id, service_settings_id, template_id, name, networks, cpu=None, ram=None, disk=None, ssh_key=None, contextualization=False, extra=None):
+def create_vm_task(
+    vm_id,
+    service_settings_id,
+    template_id,
+    name,
+    networks,
+    cpu=None,
+    ram=None,
+    disk=None,
+    ssh_key=None,
+    contextualization=False,
+    extra=None,
+):
     settings = ServiceSettings.objects.get(pk=service_settings_id)
     client = OpenNebulaClient(settings.backend_url)
     params = extra.copy() if extra else {}
     if cpu is not None:
-        params['CPU'] = cpu
+        params["CPU"] = cpu
     if ram is not None:
-        params['MEMORY'] = ram
+        params["MEMORY"] = ram
     if disk is not None:
-        params['DISK_SIZE'] = disk
+        params["DISK_SIZE"] = disk
     if ssh_key:
-        params['SSH_PUBLIC_KEY'] = ssh_key
+        params["SSH_PUBLIC_KEY"] = ssh_key
     if contextualization:
-        params['CONTEXT'] = {'SSH_PUBLIC_KEY': ssh_key} if ssh_key else {}
-    params['NIC'] = [{'NETWORK_ID': net_id} for net_id in networks]
+        params["CONTEXT"] = {"SSH_PUBLIC_KEY": ssh_key} if ssh_key else {}
+    params["NIC"] = [{"NETWORK_ID": net_id} for net_id in networks]
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['state', 'progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["state", "progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         vm.backend_id = client.create_vm(template_id, name=name, extra=params)
         vm.set_ok()
         vm.progress = 100
-        vm.save(update_fields=['state', 'backend_id', 'progress'])
+        vm.save(update_fields=["state", "backend_id", "progress"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -49,43 +67,43 @@ def create_vm_task(vm_id, service_settings_id, template_id, name, networks, cpu=
 def delete_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.schedule_deleting()
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.delete_vm(vm)
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def start_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()  # Or a custom state for starting
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.start_vm(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def stop_vm_task(vm_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     vm.begin_creating()  # Or a custom state for stopping
-    vm.save(update_fields=['state'])
+    vm.save(update_fields=["state"])
     backend = OpenNebulaBackend(vm.service_settings)
     try:
         backend.stop_vm(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -93,7 +111,7 @@ def create_tenant_task(tenant_id):
     tenant = OpenNebulaTenant.objects.get(pk=tenant_id)
     backend = OpenNebulaBackend(tenant.service_settings)
     try:
-        backend.create_tenant(tenant.name, tenant.description)
+        backend.create_tenant(tenant)
     except Exception:
         pass
 
@@ -108,7 +126,7 @@ def delete_tenant_task(tenant_id):
         pass
 
 
-@shared_task(name='opennebula.pull_tenants_task')
+@shared_task(name="opennebula.pull_tenants_task")
 def pull_tenants_task(service_settings_id):
     settings = ServiceSettings.objects.get(pk=service_settings_id)
     backend = OpenNebulaBackend(settings)
@@ -120,26 +138,27 @@ def attach_disk_task(vm_id, disk_template):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.attach_disk(vm, disk_template)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
 @shared_task
 def detach_disk_task(vm_id, disk_id):
     from .models import OpenNebulaVolume
+
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     # Find the volume by disk_id if possible
@@ -149,30 +168,31 @@ def detach_disk_task(vm_id, disk_id):
         volume = None
     if volume:
         volume.progress = 0
-        volume.error_message = ''
-        volume.save(update_fields=['progress', 'error_message'])
+        volume.error_message = ""
+        volume.save(update_fields=["progress", "error_message"])
     try:
         if volume:
             volume.progress = 50
-            volume.save(update_fields=['progress'])
+            volume.save(update_fields=["progress"])
         backend.detach_disk(vm, disk_id)
         vm.set_ok()
         if volume:
             volume.progress = 100
-            volume.save(update_fields=['progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["progress"])
+        vm.save(update_fields=["state"])
     except Exception as e:
         vm.set_erred()
         if volume:
             volume.error_message = str(e)
             volume.progress = 0
-            volume.save(update_fields=['error_message', 'progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["error_message", "progress"])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def resize_disk_task(vm_id, disk_id, size):
     from .models import OpenNebulaVolume
+
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     try:
@@ -181,25 +201,25 @@ def resize_disk_task(vm_id, disk_id, size):
         volume = None
     if volume:
         volume.progress = 0
-        volume.error_message = ''
-        volume.save(update_fields=['progress', 'error_message'])
+        volume.error_message = ""
+        volume.save(update_fields=["progress", "error_message"])
     try:
         if volume:
             volume.progress = 50
-            volume.save(update_fields=['progress'])
+            volume.save(update_fields=["progress"])
         backend.resize_disk(vm, disk_id, size)
         vm.set_ok()
         if volume:
             volume.progress = 100
-            volume.save(update_fields=['progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["progress"])
+        vm.save(update_fields=["state"])
     except Exception as e:
         vm.set_erred()
         if volume:
             volume.error_message = str(e)
             volume.progress = 0
-            volume.save(update_fields=['error_message', 'progress'])
-        vm.save(update_fields=['state'])
+            volume.save(update_fields=["error_message", "progress"])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -209,10 +229,10 @@ def create_disk_snapshot_task(vm_id, disk_id, description=None):
     try:
         backend.create_disk_snapshot(vm, disk_id, description)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -222,10 +242,10 @@ def delete_disk_snapshot_task(vm_id, disk_id, snapshot_id):
     try:
         backend.delete_disk_snapshot(vm, disk_id, snapshot_id)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -235,10 +255,10 @@ def revert_disk_snapshot_task(vm_id, disk_id, snapshot_id):
     try:
         backend.revert_disk_snapshot(vm, disk_id, snapshot_id)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -248,10 +268,10 @@ def rename_disk_snapshot_task(vm_id, disk_id, snapshot_id, new_name):
     try:
         backend.rename_disk_snapshot(vm, disk_id, snapshot_id, new_name)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -259,20 +279,20 @@ def save_disk_as_image_task(vm_id, disk_id, image_name, image_type="", snapshot_
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.save_disk_as_image(vm, disk_id, image_name, image_type, snapshot_id)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -283,10 +303,10 @@ def backup_vm_task(vm_id, ds_id, reset=False):
     try:
         backend.backup_vm(vm, ds_id, reset)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -296,10 +316,10 @@ def backup_cancel_task(vm_id):
     try:
         backend.backup_cancel(vm)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
@@ -309,115 +329,121 @@ def restore_vm_task(vm_id, backup_id, in_place=True):
     try:
         backend.restore_vm(vm, backup_id, in_place)
         vm.set_ok()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
     except Exception:
         vm.set_erred()
-        vm.save(update_fields=['state'])
+        vm.save(update_fields=["state"])
 
 
 @shared_task
 def add_ar_task(network_id, ar_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.add_ar(network, ar_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def rm_ar_task(network_id, ar_id, force=False):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.rm_ar(network, ar_id, force)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def update_ar_task(network_id, ar_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.update_ar(network, ar_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
 def reserve_ar_task(network_id, reservation_template):
     from .models import OpenNebulaNetwork
+
     network = OpenNebulaNetwork.objects.get(pk=network_id)
     backend = OpenNebulaBackend(network.service_settings)
     network.progress = 0
-    network.error_message = ''
-    network.save(update_fields=['progress', 'error_message'])
+    network.error_message = ""
+    network.save(update_fields=["progress", "error_message"])
     try:
         network.progress = 50
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
         backend.reserve_ar(network, reservation_template)
         network.progress = 100
-        network.save(update_fields=['progress'])
+        network.save(update_fields=["progress"])
     except Exception as e:
         network.error_message = str(e)
         network.progress = 0
-        network.save(update_fields=['error_message', 'progress'])
+        network.save(update_fields=["error_message", "progress"])
         raise
 
 
 @shared_task
-def migrate_vm_task(vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0):
+def migrate_vm_task(
+    vm_id, host_id, live=True, enforce=False, ds_id=None, migration_type=0
+):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.migrate_vm(vm, host_id, live, enforce, ds_id, migration_type)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -426,20 +452,20 @@ def create_vm_snapshot_task(vm_id, name):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.create_snapshot(vm, name)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -448,20 +474,20 @@ def restore_vm_snapshot_task(vm_id, snapshot_id):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.restore_vm_snapshot(vm, snapshot_id)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -470,20 +496,20 @@ def create_backup_task(vm_id, name, description=None):
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
     vm.progress = 0
-    vm.error_message = ''
-    vm.save(update_fields=['progress', 'error_message'])
+    vm.error_message = ""
+    vm.save(update_fields=["progress", "error_message"])
     try:
         vm.progress = 50
-        vm.save(update_fields=['progress'])
+        vm.save(update_fields=["progress"])
         backend.create_backup(vm, name, description)
         vm.progress = 100
         vm.set_ok()
-        vm.save(update_fields=['progress', 'state'])
+        vm.save(update_fields=["progress", "state"])
     except Exception as e:
         vm.set_erred()
         vm.error_message = str(e)
         vm.progress = 0
-        vm.save(update_fields=['state', 'error_message', 'progress'])
+        vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
@@ -493,17 +519,17 @@ def restore_backup_task(backup_id, vm_id=None, in_place=True, new_vm_name=None):
     backend = OpenNebulaBackend(vm.service_settings) if vm else None
     if vm:
         vm.progress = 0
-        vm.error_message = ''
-        vm.save(update_fields=['progress', 'error_message'])
+        vm.error_message = ""
+        vm.save(update_fields=["progress", "error_message"])
     try:
         if vm:
             if backend:
                 vm.progress = 50
-                vm.save(update_fields=['progress'])
+                vm.save(update_fields=["progress"])
                 backend.restore_backup(backup_id, vm, in_place, new_vm_name)
                 vm.progress = 100
                 vm.set_ok()
-                vm.save(update_fields=['progress', 'state'])
+                vm.save(update_fields=["progress", "state"])
         else:
             # For new VM, just call backend.restore_backup
             OpenNebulaBackend(None).restore_backup(backup_id, None, False, new_vm_name)
@@ -512,50 +538,57 @@ def restore_backup_task(backup_id, vm_id=None, in_place=True, new_vm_name=None):
             vm.set_erred()
             vm.error_message = str(e)
             vm.progress = 0
-            vm.save(update_fields=['state', 'error_message', 'progress'])
+            vm.save(update_fields=["state", "error_message", "progress"])
         raise
 
 
 @shared_task
 def run_scheduled_actions():
     now = timezone.now()
-    for action in OpenNebulaScheduledAction.objects.filter(enabled=True, next_run__lte=now):
+    for action in OpenNebulaScheduledAction.objects.filter(
+        enabled=True, next_run__lte=now
+    ):
         try:
-            if action.action_type == 'snapshot':
-                create_vm_snapshot_task.delay(action.vm.pk, action.params.get('name', f"auto-{now:%Y%m%d%H%M}"))
-            elif action.action_type == 'backup':
-                create_backup_task.delay(action.vm.pk, action.params.get('name', f"auto-backup-{now:%Y%m%d%H%M}"))
+            if action.action_type == "snapshot":
+                create_vm_snapshot_task.delay(
+                    action.vm.pk, action.params.get("name", f"auto-{now:%Y%m%d%H%M}")
+                )
+            elif action.action_type == "backup":
+                create_backup_task.delay(
+                    action.vm.pk,
+                    action.params.get("name", f"auto-backup-{now:%Y%m%d%H%M}"),
+                )
             action.last_run = now
             # Calculate next_run based on interval
-            if action.interval == 'daily':
+            if action.interval == "daily":
                 action.next_run = now + timedelta(days=1)
-            elif action.interval == 'weekly':
+            elif action.interval == "weekly":
                 action.next_run = now + timedelta(weeks=1)
             # Add more interval logic as needed
-            action.error_message = ''
+            action.error_message = ""
         except Exception as e:
             action.error_message = str(e)
-        action.save() 
+        action.save()
 
 
 @shared_task
 def list_backups_task(vm_id):
     """
     Task to list all backups of a specific virtual machine.
-    
+
     Args:
         vm_id: ID of the OpenNebulaVirtualMachine
-        
+
     Returns:
         List of backups for the specified VM
     """
     vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
     backend = OpenNebulaBackend(vm.service_settings)
-    
+
     try:
         backups = backend.list_backups(vm)
         return backups
     except Exception as e:
         vm.error_message = f"Failed to list backups: {str(e)}"
-        vm.save(update_fields=['error_message'])
+        vm.save(update_fields=["error_message"])
         raise

--- a/src/waldur_opennebula/tests/factories.py
+++ b/src/waldur_opennebula/tests/factories.py
@@ -1,6 +1,13 @@
 import factory
-from waldur_core.structure.tests.factories import ServiceSettingsFactory, ProjectFactory
-from ..models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume
+
+from waldur_core.structure.tests.factories import ProjectFactory, ServiceSettingsFactory
+
+from ..models import (
+    OpenNebulaNetwork,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+)
 
 
 class OpenNebulaTenantFactory(factory.django.DjangoModelFactory):
@@ -10,7 +17,7 @@ class OpenNebulaTenantFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"Tenant {n}")
     description = factory.Faker("sentence")
     backend_id = factory.Faker("uuid4")
-    service_settings = factory.SubFactory(ServiceSettingsFactory)
+    service_settings = factory.SubFactory(ServiceSettingsFactory, type="OpenNebula")
     project = factory.SubFactory(ProjectFactory)
 
 
@@ -21,8 +28,8 @@ class OpenNebulaVirtualMachineFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: f"VM {n}")
     description = factory.Faker("sentence")
     tenant = factory.SubFactory(OpenNebulaTenantFactory)
-    service_settings = factory.SelfAttribute('tenant.service_settings')
-    project = factory.SelfAttribute('tenant.project')
+    service_settings = factory.SelfAttribute("tenant.service_settings")
+    project = factory.SelfAttribute("tenant.project")
     backend_id = factory.Faker("uuid4")
     cpu = 2
     ram = 2048
@@ -37,7 +44,7 @@ class OpenNebulaNetworkFactory(factory.django.DjangoModelFactory):
     description = factory.Faker("sentence")
     backend_id = factory.Faker("uuid4")
     tenant = factory.SubFactory(OpenNebulaTenantFactory)
-    service_settings = factory.SelfAttribute('tenant.service_settings')
+    service_settings = factory.SelfAttribute("tenant.service_settings")
 
 
 class OpenNebulaVolumeFactory(factory.django.DjangoModelFactory):
@@ -48,5 +55,5 @@ class OpenNebulaVolumeFactory(factory.django.DjangoModelFactory):
     description = factory.Faker("sentence")
     backend_id = factory.Faker("uuid4")
     tenant = factory.SubFactory(OpenNebulaTenantFactory)
-    service_settings = factory.SelfAttribute('tenant.service_settings')
-    size = 10 
+    service_settings = factory.SelfAttribute("tenant.service_settings")
+    size = 10

--- a/src/waldur_opennebula/tests/test_backend.py
+++ b/src/waldur_opennebula/tests/test_backend.py
@@ -1,9 +1,11 @@
 import unittest
 from unittest import mock
+
 from waldur_core.structure.tests.factories import ServiceSettingsFactory
+
 from ..backend import OpenNebulaBackend
-from ..models import OpenNebulaTenant, OpenNebulaVolume, OpenNebulaNetwork
-from .. import models
+from ..models import OpenNebulaNetwork, OpenNebulaTenant, OpenNebulaVolume
+
 
 class OpenNebulaBackendVolumeTest(unittest.TestCase):
     def setUp(self):
@@ -11,54 +13,61 @@ class OpenNebulaBackendVolumeTest(unittest.TestCase):
         self.backend = OpenNebulaBackend(self.settings)
         self.backend.client = mock.Mock()
         self.tenant = mock.Mock(spec=OpenNebulaTenant)
-        self.tenant.backend_id = '1'
+        self.tenant.backend_id = "1"
         self.tenant.project = None
         self.tenant.service_settings = self.settings
 
     def test_pull_volumes(self):
-        self.backend.client.list_volumes.return_value = [mock.Mock(ID=1, NAME='vol1', DESCRIPTION='desc', SIZE=10)]
+        self.backend.client.list_volumes.return_value = [
+            mock.Mock(ID=1, NAME="vol1", DESCRIPTION="desc", SIZE=10)
+        ]
         result = self.backend.pull_volumes(self.tenant)
         self.assertEqual(len(result), 1)
         self.backend.client.list_volumes.assert_called_once()
 
     def test_create_volume(self):
         self.backend.client.create_volume.return_value = 1
-        self.backend.client.get_volume.return_value = mock.Mock(ID=1, NAME='vol1', DESCRIPTION='desc', SIZE=10)
-        vol = self.backend.create_volume(self.tenant, 'vol1', 10, 'desc')
-        self.assertEqual(vol.name, 'vol1')
-        self.backend.client.create_volume.assert_called_once_with('vol1', 10, 'desc')
+        self.backend.client.get_volume.return_value = mock.Mock(
+            ID=1, NAME="vol1", DESCRIPTION="desc", SIZE=10
+        )
+        vol = self.backend.create_volume(self.tenant, "vol1", 10, "desc")
+        self.assertEqual(vol.name, "vol1")
+        self.backend.client.create_volume.assert_called_once_with("vol1", 10, "desc")
 
     def test_delete_volume(self):
         volume = mock.Mock(spec=OpenNebulaVolume)
-        volume.backend_id = '1'
+        volume.backend_id = "1"
         self.backend.delete_volume(volume)
-        self.backend.client.delete_volume.assert_called_once_with('1')
+        self.backend.client.delete_volume.assert_called_once_with("1")
 
     def test_attach_and_detach_disk(self):
         vm = mock.Mock()
-        vm.backend_id = 'vm1'
+        vm.backend_id = "vm1"
         volume = mock.Mock()
-        volume.backend_id = 'vol1'
+        volume.backend_id = "vol1"
         self.backend.attach_disk(vm, volume)
-        self.backend.client.attach_disk.assert_called_once_with('vm1', 'vol1')
-        self.backend.detach_disk(vm, 'disk1')
-        self.backend.client.detach_disk.assert_called_once_with('vm1', 'disk1')
+        self.backend.client.attach_disk.assert_called_once_with("vm1", "vol1")
+        self.backend.detach_disk(vm, "disk1")
+        self.backend.client.detach_disk.assert_called_once_with("vm1", "disk1")
 
     def test_snapshot_and_restore(self):
         vm = mock.Mock()
-        vm.backend_id = 'vm1'
-        self.backend.snapshot_vm(vm, 'snap')
-        self.backend.client.snapshot_vm.assert_called_once_with('vm1', 'snap')
-        self.backend.restore_vm_snapshot(vm, 'snap1')
-        self.backend.client.restore_vm_snapshot.assert_called_once_with('vm1', 'snap1')
+        vm.backend_id = "vm1"
+        self.backend.snapshot_vm(vm, "snap")
+        self.backend.client.snapshot_vm.assert_called_once_with("vm1", "snap")
+        self.backend.restore_vm_snapshot(vm, "snap1")
+        self.backend.client.restore_vm_snapshot.assert_called_once_with("vm1", "snap1")
 
     def test_resize_and_save_as_image(self):
         vm = mock.Mock()
-        vm.backend_id = 'vm1'
-        self.backend.resize_disk(vm, 'disk1', 20)
-        self.backend.client.resize_disk.assert_called_once_with('vm1', 'disk1', 20)
-        self.backend.save_disk_as_image(vm, 'disk1', 'img')
-        self.backend.client.save_disk_as_image.assert_called_once_with('vm1', 'disk1', 'img', '', -1)
+        vm.backend_id = "vm1"
+        self.backend.resize_disk(vm, "disk1", 20)
+        self.backend.client.resize_disk.assert_called_once_with("vm1", "disk1", 20)
+        self.backend.save_disk_as_image(vm, "disk1", "img")
+        self.backend.client.save_disk_as_image.assert_called_once_with(
+            "vm1", "disk1", "img", "", -1
+        )
+
 
 class OpenNebulaBackendNetworkTest(unittest.TestCase):
     def setUp(self):
@@ -66,27 +75,30 @@ class OpenNebulaBackendNetworkTest(unittest.TestCase):
         self.backend = OpenNebulaBackend(self.settings)
         self.backend.client = mock.Mock()
         self.network = mock.Mock(spec=OpenNebulaNetwork)
-        self.network.backend_id = 'net1'
+        self.network.backend_id = "net1"
 
     def test_update_network(self):
-        self.backend.update_network(self.network, 'template')
-        self.backend.client.update_network.assert_called_once_with('net1', 'template')
+        self.backend.update_network(self.network, "template")
+        self.backend.client.update_network.assert_called_once_with("net1", "template")
 
     def test_add_ar(self):
-        self.backend.add_ar(self.network, 'ar_template')
-        self.backend.client.add_ar.assert_called_once_with('net1', 'ar_template')
+        self.backend.add_ar(self.network, "ar_template")
+        self.backend.client.add_ar.assert_called_once_with("net1", "ar_template")
 
     def test_rm_ar(self):
-        self.backend.rm_ar(self.network, 'ar_id', True)
-        self.backend.client.rm_ar.assert_called_once_with('net1', 'ar_id', True)
+        self.backend.rm_ar(self.network, "ar_id", True)
+        self.backend.client.rm_ar.assert_called_once_with("net1", "ar_id", True)
 
     def test_update_ar(self):
-        self.backend.update_ar(self.network, 'ar_template')
-        self.backend.client.update_ar.assert_called_once_with('net1', 'ar_template')
+        self.backend.update_ar(self.network, "ar_template")
+        self.backend.client.update_ar.assert_called_once_with("net1", "ar_template")
 
     def test_reserve_ar(self):
-        self.backend.reserve_ar(self.network, 'reservation_template')
-        self.backend.client.reserve_ar.assert_called_once_with('net1', 'reservation_template')
+        self.backend.reserve_ar(self.network, "reservation_template")
+        self.backend.client.reserve_ar.assert_called_once_with(
+            "net1", "reservation_template"
+        )
+
 
 class OpenNebulaBackendTenantTest(unittest.TestCase):
     def setUp(self):
@@ -94,32 +106,50 @@ class OpenNebulaBackendTenantTest(unittest.TestCase):
         self.backend = OpenNebulaBackend(self.settings)
         self.backend.client = mock.Mock()
         self.tenant = mock.Mock(spec=OpenNebulaTenant)
-        self.tenant.backend_id = '1'
+        self.tenant.backend_id = "1"
         self.tenant.project = None
         self.tenant.service_settings = self.settings
 
     def test_pull_tenants(self):
-        self.backend.client.list_groups.return_value = [mock.Mock(ID=1, NAME='tenant1', DESCRIPTION='desc')]
+        self.backend.client.list_groups.return_value = [
+            mock.Mock(ID=1, NAME="tenant1", DESCRIPTION="desc")
+        ]
         result = self.backend.pull_tenants()
         self.assertEqual(len(result), 1)
         self.backend.client.list_groups.assert_called_once()
 
     def test_create_tenant(self):
+        tenant = mock.Mock(spec=OpenNebulaTenant)
+        tenant.name = "tenant1"
+        tenant.description = "desc"
+        tenant.service_settings = self.settings
+        tenant.save = mock.Mock()
+        tenant.set_ok = mock.Mock()
+
         self.backend.client.create_group.return_value = 1
-        self.backend.client.get_group.return_value = mock.Mock(ID=1, NAME='tenant1', DESCRIPTION='desc')
-        tenant = self.backend.create_tenant('tenant1', 'desc')
-        self.assertEqual(tenant.name, 'tenant1')
-        self.backend.client.create_group.assert_called_once_with('tenant1', 'desc')
+
+        result = self.backend.create_tenant(tenant)
+
+        self.assertEqual(result, tenant)
+        self.backend.client.create_group.assert_called_once_with("tenant1", "desc")
+        tenant.save.assert_has_calls(
+            [
+                mock.call(update_fields=["backend_id", "service_settings"]),
+                mock.call(update_fields=["state"]),
+            ]
+        )
+        tenant.set_ok.assert_called_once()
 
     def test_delete_tenant(self):
         self.backend.delete_tenant(self.tenant)
-        self.backend.client.delete_group.assert_called_once_with('1')
+        self.backend.client.delete_group.assert_called_once_with("1")
 
     def test_set_and_get_quota(self):
-        self.backend.set_tenant_quota(self.tenant, {'CPU': 10})
-        self.backend.client.set_group_quota.assert_called_once_with(1, {'CPU': 10})
+        self.backend.set_tenant_quota(self.tenant, {"CPU": 10})
+        self.backend.client.set_group_quota.assert_called_once_with(1, {"CPU": 10})
         self.backend.get_tenant_quota(self.tenant)
         self.backend.client.get_group_quota.assert_called_once_with(1)
+
 
 class OpenNebulaBackendVMTest(unittest.TestCase):
     def setUp(self):
@@ -127,53 +157,60 @@ class OpenNebulaBackendVMTest(unittest.TestCase):
         self.backend = OpenNebulaBackend(self.settings)
         self.backend.client = mock.Mock()
         self.tenant = mock.Mock(spec=OpenNebulaTenant)
-        self.tenant.backend_id = '1'
+        self.tenant.backend_id = "1"
         self.tenant.project = None
         self.tenant.service_settings = self.settings
         self.vm = mock.Mock()
-        self.vm.backend_id = 'vm1'
+        self.vm.backend_id = "vm1"
         self.vm.tenant = self.tenant
         self.vm.project = None
         self.vm.service_settings = self.settings
 
     def test_pull_vms(self):
-        self.backend.client.list_vms.return_value = [mock.Mock(ID=1, NAME='vm1', TEMPLATE=mock.Mock(CPU=2, MEMORY=2048))]
+        self.backend.client.list_vms.return_value = [
+            mock.Mock(ID=1, NAME="vm1", TEMPLATE=mock.Mock(CPU=2, MEMORY=2048))
+        ]
         result = self.backend.pull_vms(self.tenant)
         self.assertEqual(len(result), 1)
         self.backend.client.list_vms.assert_called_once()
 
     def test_create_vm(self):
         self.backend.client.create_vm.return_value = 1
-        self.backend.client.get_vm.return_value = mock.Mock(ID=1, NAME='vm1', TEMPLATE=mock.Mock(CPU=2, MEMORY=2048))
-        vm = self.backend.create_vm(self.tenant, 'vm1', template_id=1, cpu=2, ram=2048, disk=20)
-        self.assertEqual(vm.name, 'vm1')
+        self.backend.client.get_vm.return_value = mock.Mock(
+            ID=1, NAME="vm1", TEMPLATE=mock.Mock(CPU=2, MEMORY=2048)
+        )
+        vm = self.backend.create_vm(
+            self.tenant, "vm1", template_id=1, cpu=2, ram=2048, disk=20
+        )
+        self.assertEqual(vm.name, "vm1")
         self.backend.client.create_vm.assert_called_once()
 
     def test_delete_vm(self):
         self.backend.delete_vm(self.vm)
-        self.backend.client.delete_vm.assert_called_once_with('vm1')
+        self.backend.client.delete_vm.assert_called_once_with("vm1")
 
     def test_start_stop_vm(self):
         self.backend.start_vm(self.vm)
-        self.backend.client.start_vm.assert_called_once_with('vm1')
+        self.backend.client.start_vm.assert_called_once_with("vm1")
         self.backend.stop_vm(self.vm)
-        self.backend.client.stop_vm.assert_called_once_with('vm1')
+        self.backend.client.stop_vm.assert_called_once_with("vm1")
 
     def test_reboot_and_resize_vm(self):
         self.backend.reboot_vm(self.vm)
-        self.backend.client.reboot_vm.assert_called_once_with('vm1')
+        self.backend.client.reboot_vm.assert_called_once_with("vm1")
         self.backend.resize_vm(self.vm, cpu=4, ram=4096)
-        self.backend.client.resize_vm.assert_called_once_with('vm1', cpu=4, ram=4096)
+        self.backend.client.resize_vm.assert_called_once_with("vm1", cpu=4, ram=4096)
 
     def test_snapshot_and_restore(self):
-        self.backend.snapshot_vm(self.vm, 'snap')
-        self.backend.client.snapshot_vm.assert_called_once_with('vm1', 'snap')
-        self.backend.restore_vm_snapshot(self.vm, 'snap1')
-        self.backend.client.restore_vm_snapshot.assert_called_once_with('vm1', 'snap1')
+        self.backend.snapshot_vm(self.vm, "snap")
+        self.backend.client.snapshot_vm.assert_called_once_with("vm1", "snap")
+        self.backend.restore_vm_snapshot(self.vm, "snap1")
+        self.backend.client.restore_vm_snapshot.assert_called_once_with("vm1", "snap1")
 
     def test_get_console(self):
         self.backend.get_console(self.vm)
-        self.backend.client.get_console.assert_called_once_with('vm1')
+        self.backend.client.get_console.assert_called_once_with("vm1")
+
 
 class OpenNebulaBackendBackupTest(unittest.TestCase):
     def setUp(self):
@@ -181,17 +218,17 @@ class OpenNebulaBackendBackupTest(unittest.TestCase):
         self.backend = OpenNebulaBackend(self.settings)
         self.backend.client = mock.Mock()
         self.vm = mock.Mock()
-        self.vm.backend_id = 'vm1'
+        self.vm.backend_id = "vm1"
         self.vm.service_settings = self.settings
 
     def test_backup_vm(self):
         self.backend.backup_vm(self.vm, ds_id=10, reset=True)
-        self.backend.client.backup_vm.assert_called_once_with('vm1', 10, True)
+        self.backend.client.backup_vm.assert_called_once_with("vm1", 10, True)
 
     def test_backup_cancel(self):
         self.backend.backup_cancel(self.vm)
-        self.backend.client.backup_cancel.assert_called_once_with('vm1')
+        self.backend.client.backup_cancel.assert_called_once_with("vm1")
 
     def test_restore_vm(self):
         self.backend.restore_vm(self.vm, backup_id=123, in_place=False)
-        self.backend.client.restore_vm.assert_called_once_with('vm1', 123, False) 
+        self.backend.client.restore_vm.assert_called_once_with("vm1", 123, False)

--- a/src/waldur_opennebula/tests/test_models.py
+++ b/src/waldur_opennebula/tests/test_models.py
@@ -1,9 +1,21 @@
 from django.test import TestCase
-from ..models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume
-from .factories import OpenNebulaTenantFactory, OpenNebulaVirtualMachineFactory, OpenNebulaNetworkFactory, OpenNebulaVolumeFactory
-from ..backend import OpenNebulaBackend
+
 from waldur_core.structure.tests.factories import ServiceSettingsFactory
+
+from ..backend import OpenNebulaBackend
+from ..models import (
+    OpenNebulaNetwork,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+)
 from ..utils import generate_unique_tenant_name
+from .factories import (
+    OpenNebulaNetworkFactory,
+    OpenNebulaTenantFactory,
+    OpenNebulaVirtualMachineFactory,
+    OpenNebulaVolumeFactory,
+)
 
 
 class OpenNebulaTenantModelTest(TestCase):
@@ -14,14 +26,17 @@ class OpenNebulaTenantModelTest(TestCase):
     def test_unique_constraint(self):
         tenant1 = OpenNebulaTenantFactory(backend_id="id1")
         with self.assertRaises(Exception):
-            OpenNebulaTenantFactory(backend_id="id1", service_settings=tenant1.service_settings)
+            OpenNebulaTenantFactory(
+                backend_id="id1", service_settings=tenant1.service_settings
+            )
 
     def test_create_tenant_backend(self):
         settings = ServiceSettingsFactory()
         backend = OpenNebulaBackend(settings)
         # This will fail unless pyone is mocked, but demonstrates backend usage
         try:
-            backend.create_tenant(name="Backend Tenant", description="desc")
+            tenant = OpenNebulaTenantFactory(service_settings=settings)
+            backend.create_tenant(tenant)
         except Exception:
             pass
 
@@ -50,6 +65,7 @@ class OpenNebulaTenantModelTest(TestCase):
     def test_invalid_backend_id(self):
         tenant = OpenNebulaTenantFactory.build(backend_id=None)
         from django.core.exceptions import ValidationError
+
         with self.assertRaises(ValidationError):
             tenant.full_clean()
 
@@ -65,6 +81,7 @@ class OpenNebulaVirtualMachineModelTest(TestCase):
 
     def test_invalid_cpu_ram_disk(self):
         from django.core.exceptions import ValidationError
+
         vm = OpenNebulaVirtualMachineFactory.build(cpu=-1, ram=-1, disk=-1)
         with self.assertRaises(ValidationError):
             vm.full_clean()
@@ -78,7 +95,9 @@ class OpenNebulaNetworkModelTest(TestCase):
     def test_unique_constraint(self):
         network1 = OpenNebulaNetworkFactory(backend_id="id1")
         with self.assertRaises(Exception):
-            OpenNebulaNetworkFactory(backend_id="id1", service_settings=network1.service_settings)
+            OpenNebulaNetworkFactory(
+                backend_id="id1", service_settings=network1.service_settings
+            )
 
     def test_required_fields(self):
         with self.assertRaises(Exception):
@@ -86,6 +105,7 @@ class OpenNebulaNetworkModelTest(TestCase):
 
     def test_invalid_backend_id(self):
         from django.core.exceptions import ValidationError
+
         network = OpenNebulaNetworkFactory.build(backend_id=None)
         with self.assertRaises(ValidationError):
             network.full_clean()
@@ -99,7 +119,9 @@ class OpenNebulaVolumeModelTest(TestCase):
     def test_unique_constraint(self):
         volume1 = OpenNebulaVolumeFactory(backend_id="id1")
         with self.assertRaises(Exception):
-            OpenNebulaVolumeFactory(backend_id="id1", service_settings=volume1.service_settings)
+            OpenNebulaVolumeFactory(
+                backend_id="id1", service_settings=volume1.service_settings
+            )
 
     def test_required_fields(self):
         with self.assertRaises(Exception):
@@ -107,6 +129,7 @@ class OpenNebulaVolumeModelTest(TestCase):
 
     def test_invalid_size(self):
         from django.core.exceptions import ValidationError
+
         volume = OpenNebulaVolumeFactory.build(size=-1)
         with self.assertRaises(ValidationError):
-            volume.full_clean() 
+            volume.full_clean()

--- a/src/waldur_opennebula/views.py
+++ b/src/waldur_opennebula/views.py
@@ -1,27 +1,64 @@
-from rest_framework import viewsets, status
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from .models import OpenNebulaTenant, OpenNebulaVirtualMachine, OpenNebulaNetwork, OpenNebulaVolume, OpenNebulaScheduledAction
-from .serializers import OpenNebulaTenantSerializer, OpenNebulaTenantCreateSerializer, OpenNebulaVirtualMachineSerializer, OpenNebulaNetworkSerializer, OpenNebulaVolumeSerializer, OpenNebulaVMCreateSerializer, OpenNebulaVMMigrateSerializer, OpenNebulaDiskAttachSerializer, OpenNebulaDiskResizeSerializer, OpenNebulaDiskSaveAsSerializer, OpenNebulaVMSnapshotSerializer, OpenNebulaVMListSnapshotsSerializer, OpenNebulaBackupCreateSerializer, OpenNebulaBackupListSerializer, OpenNebulaRestoreBackupSerializer, OpenNebulaFloatingIPAssignSerializer, OpenNebulaFloatingIPReleaseSerializer, OpenNebulaMarketplaceOfferingSerializer, OpenNebulaVMMonitoringSerializer, OpenNebulaQuotaSerializer, OpenNebulaScheduledActionSerializer, OpenNebulaNetworkAttachSerializer, OpenNebulaNetworkReleaseSerializer, OpenNebulaNetworkUpdateSerializer, OpenNebulaNetworkListSerializer
-from .executors import (
-    AttachDiskExecutor, DetachDiskExecutor, NetworkDeleteExecutor,
-    VolumeDeleteExecutor, ResizeDiskExecutor,
-    CreateDiskSnapshotExecutor, DeleteDiskSnapshotExecutor,
-    RevertDiskSnapshotExecutor, RenameDiskSnapshotExecutor,
-    SaveDiskAsImageExecutor, BackupVMExecutor,
-    BackupCancelExecutor, RestoreVMExecutor, OpenNebulaCleanupExecutor,
-    VirtualMachineCreateExecutor, VirtualMachineDeleteExecutor,
-    VirtualMachinePullExecutor, VirtualMachineRebootExecutor,
-    VirtualMachineStartExecutor, VirtualMachineStopExecutor,
-    TenantPullExecutor, TenantDeleteExecutor
-)
-from .backend import OpenNebulaBackend
 from rest_framework.views import APIView
-from .client import OpenNebulaClient
+
 from waldur_core.structure.models import ServiceSettings
-from drf_spectacular.utils import extend_schema, OpenApiParameter, OpenApiResponse
-from .tasks import create_vm_task, migrate_vm_task, attach_disk_task, resize_disk_task, save_disk_as_image_task, create_vm_snapshot_task, restore_vm_snapshot_task, create_backup_task, list_backups_task, restore_backup_task
-from django.shortcuts import get_object_or_404
+
+from .backend import OpenNebulaBackend
+from .client import OpenNebulaClient
+from .executors import (
+    TenantPullExecutor,
+    VirtualMachineCreateExecutor,
+    VirtualMachineDeleteExecutor,
+    VirtualMachineRebootExecutor,
+    VirtualMachineStartExecutor,
+    VirtualMachineStopExecutor,
+)
+from .models import (
+    OpenNebulaNetwork,
+    OpenNebulaScheduledAction,
+    OpenNebulaTenant,
+    OpenNebulaVirtualMachine,
+    OpenNebulaVolume,
+)
+from .serializers import (
+    OpenNebulaBackupCreateSerializer,
+    OpenNebulaBackupListSerializer,
+    OpenNebulaDiskAttachSerializer,
+    OpenNebulaDiskResizeSerializer,
+    OpenNebulaDiskSaveAsSerializer,
+    OpenNebulaMarketplaceOfferingSerializer,
+    OpenNebulaNetworkAttachSerializer,
+    OpenNebulaNetworkListSerializer,
+    OpenNebulaNetworkReleaseSerializer,
+    OpenNebulaNetworkSerializer,
+    OpenNebulaNetworkUpdateSerializer,
+    OpenNebulaQuotaSerializer,
+    OpenNebulaRestoreBackupSerializer,
+    OpenNebulaScheduledActionSerializer,
+    OpenNebulaTenantCreateSerializer,
+    OpenNebulaTenantSerializer,
+    OpenNebulaVirtualMachineSerializer,
+    OpenNebulaVMCreateSerializer,
+    OpenNebulaVMListSnapshotsSerializer,
+    OpenNebulaVMMigrateSerializer,
+    OpenNebulaVMMonitoringSerializer,
+    OpenNebulaVMSnapshotSerializer,
+    OpenNebulaVolumeSerializer,
+)
+from .tasks import (
+    attach_disk_task,
+    create_backup_task,
+    create_vm_snapshot_task,
+    create_vm_task,
+    migrate_vm_task,
+    resize_disk_task,
+    restore_backup_task,
+    save_disk_as_image_task,
+)
 
 
 class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
@@ -29,84 +66,120 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
     serializer_class = OpenNebulaTenantSerializer
 
     def create(self, request, *args, **kwargs):
-        serializer = OpenNebulaTenantCreateSerializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        backend = OpenNebulaBackend(request.user.service_settings)
-        tenant = backend.create_tenant(
-            name=serializer.validated_data['name'],
-            description=serializer.validated_data.get('description', ''),
+        serializer = OpenNebulaTenantCreateSerializer(
+            data=request.data, context={"request": request}
         )
-        return Response(OpenNebulaTenantSerializer(tenant).data, status=status.HTTP_201_CREATED)
+        serializer.is_valid(raise_exception=True)
+        tenant = serializer.save()
+        backend = OpenNebulaBackend(tenant.service_settings)
+        backend.create_tenant(tenant)
+        response_serializer = OpenNebulaTenantSerializer(
+            tenant, context={"request": request}
+        )
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
-    @action(detail=True, methods=['delete'])
+    @action(detail=True, methods=["delete"])
     def delete_tenant(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
         backend.delete_tenant(tenant)
-        return Response({'detail': 'Tenant deleted.'}, status=status.HTTP_204_NO_CONTENT)
+        return Response(
+            {"detail": "Tenant deleted."}, status=status.HTTP_204_NO_CONTENT
+        )
 
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def pull(self, request):
-        service_settings_id = request.data.get('service_settings_id')
+        service_settings_id = request.data.get("service_settings_id")
         if not service_settings_id:
-            return Response({'detail': 'service_settings_id required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings_id required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         TenantPullExecutor.execute(service_settings_id)
-        return Response({'detail': 'Pull scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Pull scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def set_quotas(self, request, pk=None):
         tenant = self.get_object()
-        quota_template = request.data.get('quota_template')
+        quota_template = request.data.get("quota_template")
         if not quota_template:
-            return Response({'detail': 'quota_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "quota_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(tenant.service_settings)
         try:
             result = backend.set_tenant_quota(tenant, quota_template)
-            return Response({'detail': 'Quota set.', 'result': str(result)}, status=status.HTTP_200_OK)
+            return Response(
+                {"detail": "Quota set.", "result": str(result)},
+                status=status.HTTP_200_OK,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def pull_quotas(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
         try:
             quotas = backend.get_tenant_quota(tenant)
-            return Response({'quotas': str(quotas)}, status=status.HTTP_200_OK)
+            return Response({"quotas": str(quotas)}, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_network(self, request, pk=None):
         # This could be implemented if OpenNebula supports network creation per group/project
-        return Response({'detail': 'Network creation for tenant is not implemented yet.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Network creation for tenant is not implemented yet."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_floating_ip(self, request, pk=None):
         # OpenNebula does not have a direct floating IP concept like OpenStack
-        return Response({'detail': 'Floating IPs are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Floating IPs are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_floating_ips(self, request, pk=None):
         # OpenNebula does not have a direct floating IP concept like OpenStack
-        return Response({'detail': 'Floating IPs are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Floating IPs are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_security_groups(self, request, pk=None):
         # OpenNebula does not have security groups like OpenStack
-        return Response({'detail': 'Security groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Security groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def pull_server_groups(self, request, pk=None):
         # OpenNebula does not have server groups like OpenStack
-        return Response({'detail': 'Server groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Server groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_server_group(self, request, pk=None):
         # OpenNebula does not have server groups like OpenStack
-        return Response({'detail': 'Server groups are not supported by OpenNebula.'}, status=status.HTTP_501_NOT_IMPLEMENTED)
+        return Response(
+            {"detail": "Server groups are not supported by OpenNebula."},
+            status=status.HTTP_501_NOT_IMPLEMENTED,
+        )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_instances(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -115,10 +188,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVirtualMachineSerializer(vms, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_vms(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -127,9 +201,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVirtualMachineSerializer(vms, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_volumes(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -138,9 +214,11 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaVolumeSerializer(volumes, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def backend_networks(self, request, pk=None):
         tenant = self.get_object()
         backend = OpenNebulaBackend(tenant.service_settings)
@@ -149,369 +227,479 @@ class OpenNebulaTenantViewSet(viewsets.ModelViewSet):
             data = OpenNebulaNetworkSerializer(networks, many=True).data
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaVirtualMachineViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaVirtualMachine.objects.all()
     serializer_class = OpenNebulaVirtualMachineSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def start(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineStartExecutor.execute(vm)
-        return Response({'detail': 'Start scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Start scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def reboot(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineRebootExecutor.execute(vm)
-        return Response({'detail': 'Start scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Start scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def stop(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineStopExecutor.execute(vm)
-        return Response({'detail': 'Stop scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response({"detail": "Stop scheduled."}, status=status.HTTP_202_ACCEPTED)
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def delete_vm(self, request, pk=None):
         vm = self.get_object()
         VirtualMachineDeleteExecutor.execute(vm)
-        return Response({'detail': 'Delete scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Delete scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         instance = serializer.save()
         VirtualMachineCreateExecutor.execute(instance)
-        return Response(self.get_serializer(instance).data, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            self.get_serializer(instance).data, status=status.HTTP_202_ACCEPTED
+        )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restart(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.reboot_vm(vm)
-            return Response({'detail': 'Restart scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restart scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def resize(self, request, pk=None):
         vm = self.get_object()
-        cpu = request.data.get('cpu')
-        ram = request.data.get('ram')
+        cpu = request.data.get("cpu")
+        ram = request.data.get("ram")
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.resize_vm(vm, cpu=cpu, ram=ram)
-            return Response({'detail': 'Resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Resize scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def attach_volume(self, request, pk=None):
         vm = self.get_object()
-        volume_id = request.data.get('volume_id')
+        volume_id = request.data.get("volume_id")
         if not volume_id:
-            return Response({'detail': 'volume_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "volume_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         from .models import OpenNebulaVolume
+
         try:
             volume = OpenNebulaVolume.objects.get(pk=volume_id)
         except OpenNebulaVolume.DoesNotExist:
-            return Response({'detail': 'Volume not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "Volume not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.attach_disk(vm, volume)
-            return Response({'detail': 'Attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Attach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def detach_volume(self, request, pk=None):
         vm = self.get_object()
-        disk_id = request.data.get('disk_id')
+        disk_id = request.data.get("disk_id")
         if not disk_id:
-            return Response({'detail': 'disk_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "disk_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.detach_disk(vm, disk_id)
-            return Response({'detail': 'Detach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Detach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def snapshot(self, request, pk=None):
         vm = self.get_object()
-        name = request.data.get('name')
+        name = request.data.get("name")
         if not name:
-            return Response({'detail': 'name is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "name is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.snapshot_vm(vm, name)
-            return Response({'detail': 'Snapshot scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restore_snapshot(self, request, pk=None):
         vm = self.get_object()
-        snapshot_id = request.data.get('snapshot_id')
+        snapshot_id = request.data.get("snapshot_id")
         if not snapshot_id:
-            return Response({'detail': 'snapshot_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "snapshot_id is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.restore_vm_snapshot(vm, snapshot_id)
-            return Response({'detail': 'Restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restore scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def console(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             console_info = backend.get_console(vm)
-            return Response({'console': str(console_info)}, status=status.HTTP_200_OK)
+            return Response({"console": str(console_info)}, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def backup(self, request, pk=None):
         vm = self.get_object()
-        ds_id = request.data.get('ds_id')
-        reset = request.data.get('reset', False)
+        ds_id = request.data.get("ds_id")
+        reset = request.data.get("reset", False)
         if not ds_id:
-            return Response({'detail': 'ds_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ds_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.backup_vm(vm, ds_id, reset)
-            return Response({'detail': 'Backup scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Backup scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def backup_cancel(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.backup_cancel(vm)
-            return Response({'detail': 'Backup cancel scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Backup cancel scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def restore(self, request, pk=None):
         vm = self.get_object()
-        backup_id = request.data.get('backup_id')
-        in_place = request.data.get('in_place', True)
+        backup_id = request.data.get("backup_id")
+        in_place = request.data.get("in_place", True)
         if not backup_id:
-            return Response({'detail': 'backup_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "backup_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(vm.service_settings)
         try:
             backend.restore_vm(vm, backup_id, in_place)
-            return Response({'detail': 'Restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Restore scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaVMCreateSerializer,
-        responses={201: OpenApiResponse(description='VM created'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a new VM with the selected template, networks, and options."
+        responses={
+            201: OpenApiResponse(description="VM created"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a new VM with the selected template, networks, and options.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_vm(self, request):
         serializer = OpenNebulaVMCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        settings = data['service_settings']
+        settings = data["service_settings"]
         # Create DB record for VM in 'creating' state
         vm = OpenNebulaVirtualMachine.objects.create(
-            name=data['name'],
+            name=data["name"],
             service_settings=settings,
-            state='creating',
+            state="creating",
             # Add other required fields as needed (e.g., project, tenant)
         )
         # Schedule async Celery task
         create_vm_task(
             vm.pk,
             settings.pk,
-            data['template_id'],
-            data['name'],
-            data['networks'],
-            data.get('cpu'),
-            data.get('ram'),
-            data.get('disk'),
-            data.get('ssh_key'),
-            data.get('contextualization', False),
-            data.get('extra', {}),
+            data["template_id"],
+            data["name"],
+            data["networks"],
+            data.get("cpu"),
+            data.get("ram"),
+            data.get("disk"),
+            data.get("ssh_key"),
+            data.get("contextualization", False),
+            data.get("extra", {}),
         )
         # Return VM object (with state) for polling
-        return Response(OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED)
+        return Response(
+            OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED
+        )
 
     @extend_schema(
         request=OpenNebulaVMMigrateSerializer,
-        responses={202: OpenApiResponse(description='Migration scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Migrate a VM to a target host/datastore."
+        responses={
+            202: OpenApiResponse(description="Migration scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Migrate a VM to a target host/datastore.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def migrate(self, request):
         serializer = OpenNebulaVMMigrateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         migrate_vm_task(
             vm.pk,
-            data['host_id'],
-            data.get('live', True),
-            data.get('enforce', False),
-            data.get('ds_id'),
-            data.get('migration_type', 0),
+            data["host_id"],
+            data.get("live", True),
+            data.get("enforce", False),
+            data.get("ds_id"),
+            data.get("migration_type", 0),
         )
-        return Response({'detail': 'Migration scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Migration scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskAttachSerializer,
-        responses={202: OpenApiResponse(description='Disk attach scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Attach a disk/image to a VM."
+        responses={
+            202: OpenApiResponse(description="Disk attach scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Attach a disk/image to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def attach_disk(self, request):
         serializer = OpenNebulaDiskAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         disk_template = {
-            'IMAGE_ID': data['image_id'],
+            "IMAGE_ID": data["image_id"],
         }
-        if data.get('size'):
-            disk_template['SIZE'] = data['size']
-        if data.get('type'):
-            disk_template['TYPE'] = data['type']
-        if data.get('target'):
-            disk_template['TARGET'] = data['target']
+        if data.get("size"):
+            disk_template["SIZE"] = data["size"]
+        if data.get("type"):
+            disk_template["TYPE"] = data["type"]
+        if data.get("target"):
+            disk_template["TARGET"] = data["target"]
         attach_disk_task(vm.pk, disk_template)
-        return Response({'detail': 'Disk attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Disk attach scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskResizeSerializer,
-        responses={202: OpenApiResponse(description='Disk resize scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Resize a disk attached to a VM."
+        responses={
+            202: OpenApiResponse(description="Disk resize scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Resize a disk attached to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def resize_disk(self, request):
         serializer = OpenNebulaDiskResizeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        resize_disk_task(vm.pk, data['disk_id'], data['size'])
-        return Response({'detail': 'Disk resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        vm = data["vm"]
+        resize_disk_task(vm.pk, data["disk_id"], data["size"])
+        return Response(
+            {"detail": "Disk resize scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaDiskSaveAsSerializer,
-        responses={202: OpenApiResponse(description='Save disk as image scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Save a disk as a new image."
+        responses={
+            202: OpenApiResponse(description="Save disk as image scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Save a disk as a new image.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def save_disk_as_image(self, request):
         serializer = OpenNebulaDiskSaveAsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         save_disk_as_image_task(
             vm.pk,
-            data['disk_id'],
-            data['image_name'],
-            data.get('image_type', ''),
-            data.get('snapshot_id', -1),
+            data["disk_id"],
+            data["image_name"],
+            data.get("image_type", ""),
+            data.get("snapshot_id", -1),
         )
-        return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaVMSnapshotSerializer,
-        responses={202: OpenApiResponse(description='Snapshot creation scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a snapshot for a VM."
+        responses={
+            202: OpenApiResponse(description="Snapshot creation scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a snapshot for a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_snapshot(self, request):
         serializer = OpenNebulaVMSnapshotSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_vm_snapshot_task(data['vm'].pk, data['name'])
-        return Response({'detail': 'Snapshot creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_vm_snapshot_task(data["vm"].pk, data["name"])
+        return Response(
+            {"detail": "Snapshot creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaVMListSnapshotsSerializer,
-        responses={200: OpenApiResponse(description='List of VM snapshots'), 400: OpenApiResponse(description='Validation error')},
-        description="List all snapshots for a VM."
+        responses={
+            200: OpenApiResponse(description="List of VM snapshots"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="List all snapshots for a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_snapshots(self, request):
         serializer = OpenNebulaVMListSnapshotsSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             snapshots = backend.list_snapshots(vm)
             return Response(snapshots, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaBackupCreateSerializer,
-        responses={202: OpenApiResponse(description='Backup creation scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Create a backup for a VM."
+        responses={
+            202: OpenApiResponse(description="Backup creation scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Create a backup for a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def create_backup(self, request):
         serializer = OpenNebulaBackupCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_backup_task(data['vm'].pk, data['name'], data.get('description', ''))
-        return Response({'detail': 'Backup creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_backup_task(data["vm"].pk, data["name"], data.get("description", ""))
+        return Response(
+            {"detail": "Backup creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         request=OpenNebulaBackupListSerializer,
-        responses={200: OpenApiResponse(description='List of VM backups'), 400: OpenApiResponse(description='Validation error')},
-        description="List all backups for a VM."
+        responses={
+            200: OpenApiResponse(description="List of VM backups"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="List all backups for a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_backups(self, request):
         serializer = OpenNebulaBackupListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             backups = backend.list_backups(vm)
             return Response(backups, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaRestoreBackupSerializer,
-        responses={202: OpenApiResponse(description='Backup restore scheduled'), 400: OpenApiResponse(description='Validation error')},
-        description="Restore a backup to a VM or as a new VM."
+        responses={
+            202: OpenApiResponse(description="Backup restore scheduled"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Restore a backup to a VM or as a new VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def restore_backup(self, request):
         serializer = OpenNebulaRestoreBackupSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         restore_backup_task(
-            data['backup_id'],
-            data.get('vm').pk if data.get('vm') else None,
-            data.get('in_place', True),
-            data.get('new_vm_name', ''),
+            data["backup_id"],
+            data.get("vm").pk if data.get("vm") else None,
+            data.get("in_place", True),
+            data.get("new_vm_name", ""),
         )
-        return Response({'detail': 'Backup restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Backup restore scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
 
     @extend_schema(
         responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer)},
-        description="Get monitoring data for a VM."
+        description="Get monitoring data for a VM.",
     )
-    @action(detail=True, methods=['get'])
+    @action(detail=True, methods=["get"])
     def monitoring(self, request, pk=None):
         vm = self.get_object()
         backend = OpenNebulaBackend(vm.service_settings)
@@ -520,584 +708,845 @@ class OpenNebulaVirtualMachineViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer(many=True))},
-        description="Get monitoring data for all VMs."
+        description="Get monitoring data for all VMs.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def pool_monitoring(self, request):
         # Optionally filter by user/project
-        backend = OpenNebulaBackend(ServiceSettings.objects.filter(type='OpenNebula').first())
+        backend = OpenNebulaBackend(
+            ServiceSettings.objects.filter(type="OpenNebula").first()
+        )
         data = backend.get_vmpool_monitoring()
         return Response(data, status=status.HTTP_200_OK)
 
     @extend_schema(
         request=OpenNebulaNetworkAttachSerializer,
-        responses={200: OpenApiResponse(description='NIC attached'), 400: OpenApiResponse(description='Validation error')},
-        description="Attach a network interface to a VM."
+        responses={
+            200: OpenApiResponse(description="NIC attached"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Attach a network interface to a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def attach_nic(self, request):
         serializer = OpenNebulaNetworkAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
+            backend = OpenNebulaBackend(data["vm"].service_settings)
             result = backend.attach_nic(
-                data['vm'], 
-                data['network_id'], 
-                ip=data.get('ip_address'), 
-                model=data.get('model')
+                data["vm"],
+                data["network_id"],
+                ip=data.get("ip_address"),
+                model=data.get("model"),
             )
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaNetworkReleaseSerializer,
-        responses={200: OpenApiResponse(description='NIC detached'), 400: OpenApiResponse(description='Validation error')},
-        description="Detach a network interface from a VM."
+        responses={
+            200: OpenApiResponse(description="NIC detached"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Detach a network interface from a VM.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def detach_nic(self, request):
         serializer = OpenNebulaNetworkReleaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            result = backend.detach_nic(data['vm'], data['nic_id'])
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+            result = backend.detach_nic(data["vm"], data["nic_id"])
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
     @extend_schema(
         request=OpenNebulaNetworkUpdateSerializer,
-        responses={200: OpenApiResponse(description='NIC updated'), 400: OpenApiResponse(description='Validation error')},
-        description="Update a network interface configuration."
+        responses={
+            200: OpenApiResponse(description="NIC updated"),
+            400: OpenApiResponse(description="Validation error"),
+        },
+        description="Update a network interface configuration.",
     )
-    @action(detail=False, methods=['post'])
+    @action(detail=False, methods=["post"])
     def update_nic(self, request):
         serializer = OpenNebulaNetworkUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+
             # Extract kwargs from the validated data, removing vm and nic_id
-            kwargs = {k: v for k, v in data.items() if k not in ['vm', 'nic_id']}
-            
-            result = backend.update_nic(data['vm'], data['nic_id'], **kwargs)
+            kwargs = {k: v for k, v in data.items() if k not in ["vm", "nic_id"]}
+
+            result = backend.update_nic(data["vm"], data["nic_id"], **kwargs)
             return Response(result, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         request=OpenNebulaNetworkListSerializer,
-        responses={200: OpenApiResponse(description='List of NICs attached to VM')},
-        description="List all network interfaces attached to a VM."
+        responses={200: OpenApiResponse(description="List of NICs attached to VM")},
+        description="List all network interfaces attached to a VM.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_nics(self, request):
         serializer = OpenNebulaNetworkListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         try:
-            backend = OpenNebulaBackend(data['vm'].service_settings)
-            nics = backend.list_nics(data['vm'])
+            backend = OpenNebulaBackend(data["vm"].service_settings)
+            nics = backend.list_nics(data["vm"])
             return Response(nics, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaNetworkViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaNetwork.objects.all()
     serializer_class = OpenNebulaNetworkSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def update_network(self, request, pk=None):
         network = self.get_object()
-        template = request.data.get('template')
+        template = request.data.get("template")
         if not template:
-            return Response({'detail': 'template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "template is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.update_network(network, template)
-            return Response({'detail': 'Network update scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Network update scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def add_ar(self, request, pk=None):
         network = self.get_object()
-        ar_template = request.data.get('ar_template')
+        ar_template = request.data.get("ar_template")
         if not ar_template:
-            return Response({'detail': 'ar_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.add_ar(network, ar_template)
-            return Response({'detail': 'Address range add scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range add scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def rm_ar(self, request, pk=None):
         network = self.get_object()
-        ar_id = request.data.get('ar_id')
-        force = request.data.get('force', False)
+        ar_id = request.data.get("ar_id")
+        force = request.data.get("force", False)
         if ar_id is None:
-            return Response({'detail': 'ar_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.rm_ar(network, ar_id, force)
-            return Response({'detail': 'Address range remove scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range remove scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def update_ar(self, request, pk=None):
         network = self.get_object()
-        ar_template = request.data.get('ar_template')
+        ar_template = request.data.get("ar_template")
         if not ar_template:
-            return Response({'detail': 'ar_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "ar_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.update_ar(network, ar_template)
-            return Response({'detail': 'Address range update scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address range update scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def reserve_ar(self, request, pk=None):
         network = self.get_object()
-        reservation_template = request.data.get('reservation_template')
+        reservation_template = request.data.get("reservation_template")
         if not reservation_template:
-            return Response({'detail': 'reservation_template is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "reservation_template is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         backend = OpenNebulaBackend(network.service_settings)
         try:
             backend.reserve_ar(network, reservation_template)
-            return Response({'detail': 'Address reservation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Address reservation scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of networks')},
-        description="List available networks for VM deployment."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of networks")},
+        description="List available networks for VM deployment.",
     )
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=["get"])
     def list_all(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             networks = client.list_networks()
             data = [
-                {'id': n.ID, 'name': n.NAME, 'bridge': getattr(n, 'BRIDGE', None), 'vlan_id': getattr(n, 'VLAN_ID', None)}
-                for n in getattr(networks, 'VNET', [])
+                {
+                    "id": n.ID,
+                    "name": n.NAME,
+                    "bridge": getattr(n, "BRIDGE", None),
+                    "vlan_id": getattr(n, "VLAN_ID", None),
+                }
+                for n in getattr(networks, "VNET", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 class OpenNebulaVolumeViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaVolume.objects.all()
     serializer_class = OpenNebulaVolumeSerializer
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def attach_to_vm(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
+        vm_id = request.data.get("vm_id")
         if not vm_id:
-            return Response({'detail': 'vm_id is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id is required."}, status=status.HTTP_400_BAD_REQUEST
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.attach_disk(vm, volume)
-            return Response({'detail': 'Attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Attach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def detach_from_vm(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
         if not vm_id or not disk_id:
-            return Response({'detail': 'vm_id and disk_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id and disk_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.detach_disk(vm, disk_id)
-            return Response({'detail': 'Detach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Detach scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def create_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        description = request.data.get('description')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        description = request.data.get("description")
         if not vm_id or not disk_id:
-            return Response({'detail': 'vm_id and disk_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id and disk_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.create_disk_snapshot(vm, disk_id, description)
-            return Response({'detail': 'Snapshot scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def delete_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
         if not vm_id or not disk_id or not snapshot_id:
-            return Response({'detail': 'vm_id, disk_id, and snapshot_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and snapshot_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.delete_disk_snapshot(vm, disk_id, snapshot_id)
-            return Response({'detail': 'Snapshot delete scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot delete scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def revert_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
         if not vm_id or not disk_id or not snapshot_id:
-            return Response({'detail': 'vm_id, disk_id, and snapshot_id are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and snapshot_id are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.revert_disk_snapshot(vm, disk_id, snapshot_id)
-            return Response({'detail': 'Snapshot revert scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot revert scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def rename_snapshot(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        snapshot_id = request.data.get('snapshot_id')
-        new_name = request.data.get('new_name')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        snapshot_id = request.data.get("snapshot_id")
+        new_name = request.data.get("new_name")
         if not vm_id or not disk_id or not snapshot_id or not new_name:
-            return Response({'detail': 'vm_id, disk_id, snapshot_id, and new_name are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, snapshot_id, and new_name are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.rename_disk_snapshot(vm, disk_id, snapshot_id, new_name)
-            return Response({'detail': 'Snapshot rename scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Snapshot rename scheduled."},
+                status=status.HTTP_202_ACCEPTED,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def resize(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        size = request.data.get('size')
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        size = request.data.get("size")
         if not vm_id or not disk_id or not size:
-            return Response({'detail': 'vm_id, disk_id, and size are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and size are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.resize_disk(vm, disk_id, size)
-            return Response({'detail': 'Resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Resize scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
-    @action(detail=True, methods=['post'])
+    @action(detail=True, methods=["post"])
     def save_as_image(self, request, pk=None):
         volume = self.get_object()
-        vm_id = request.data.get('vm_id')
-        disk_id = request.data.get('disk_id')
-        image_name = request.data.get('image_name')
-        image_type = request.data.get('image_type', "")
-        snapshot_id = request.data.get('snapshot_id', -1)
+        vm_id = request.data.get("vm_id")
+        disk_id = request.data.get("disk_id")
+        image_name = request.data.get("image_name")
+        image_type = request.data.get("image_type", "")
+        snapshot_id = request.data.get("snapshot_id", -1)
         if not vm_id or not disk_id or not image_name:
-            return Response({'detail': 'vm_id, disk_id, and image_name are required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "vm_id, disk_id, and image_name are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         from .models import OpenNebulaVirtualMachine
+
         try:
             vm = OpenNebulaVirtualMachine.objects.get(pk=vm_id)
         except OpenNebulaVirtualMachine.DoesNotExist:
-            return Response({'detail': 'VM not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "VM not found."}, status=status.HTTP_404_NOT_FOUND
+            )
         backend = OpenNebulaBackend(volume.service_settings)
         try:
             backend.save_disk_as_image(vm, disk_id, image_name, image_type, snapshot_id)
-            return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+            return Response(
+                {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
-    parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-    responses={200: OpenApiResponse(description='List of VM templates')},
-    description="List available VM templates for deployment."
+    parameters=[
+        OpenApiParameter(
+            "service_settings", type=int, required=True, location=OpenApiParameter.QUERY
+        )
+    ],
+    responses={200: OpenApiResponse(description="List of VM templates")},
+    description="List available VM templates for deployment.",
 )
 class OpenNebulaTemplateListView(APIView):
     def get(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(settings)
             templates = client.list_templates()
             # Minimal serialization for wizard
             data = [
-                {'id': t.ID, 'name': t.NAME, 'cpu': getattr(t.TEMPLATE, 'CPU', None), 'memory': getattr(t.TEMPLATE, 'MEMORY', None)}
-                for t in getattr(templates, 'VMTEMPLATE', [])
+                {
+                    "id": t.ID,
+                    "name": t.NAME,
+                    "cpu": getattr(t.TEMPLATE, "CPU", None),
+                    "memory": getattr(t.TEMPLATE, "MEMORY", None),
+                }
+                for t in getattr(templates, "VMTEMPLATE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
-    parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-    responses={200: OpenApiResponse(description='List of images')},
-    description="List available images for disk attach or VM creation."
+    parameters=[
+        OpenApiParameter(
+            "service_settings", type=int, required=True, location=OpenApiParameter.QUERY
+        )
+    ],
+    responses={200: OpenApiResponse(description="List of images")},
+    description="List available images for disk attach or VM creation.",
 )
 class OpenNebulaImageListView(APIView):
     def get(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(
+                settings.backend_url, settings.username, settings.password
+            )
             images = client.list_images()
             data = [
-                {'id': i.ID, 'name': i.NAME, 'size': getattr(i, 'SIZE', None), 'type': getattr(i, 'TYPE', None)}
-                for i in getattr(images, 'IMAGE', [])
+                {
+                    "id": i.ID,
+                    "name": i.NAME,
+                    "size": getattr(i, "SIZE", None),
+                    "type": getattr(i, "TYPE", None),
+                }
+                for i in getattr(images, "IMAGE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
 
 
 @extend_schema(
     request=OpenNebulaVMCreateSerializer,
-    responses={201: OpenApiResponse(description='VM created'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a new VM with the selected template, networks, and options."
+    responses={
+        201: OpenApiResponse(description="VM created"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a new VM with the selected template, networks, and options.",
 )
 class OpenNebulaVMCreateView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        settings = data['service_settings']
+        settings = data["service_settings"]
         # Create DB record for VM in 'creating' state
         vm = OpenNebulaVirtualMachine.objects.create(
-            name=data['name'],
+            name=data["name"],
             service_settings=settings,
-            state='creating',
+            state="creating",
             # Add other required fields as needed (e.g., project, tenant)
         )
         # Schedule async Celery task
         create_vm_task(
             vm.pk,
             settings.pk,
-            data['template_id'],
-            data['name'],
-            data['networks'],
-            data.get('cpu'),
-            data.get('ram'),
-            data.get('disk'),
-            data.get('ssh_key'),
-            data.get('contextualization', False),
-            data.get('extra', {}),
+            data["template_id"],
+            data["name"],
+            data["networks"],
+            data.get("cpu"),
+            data.get("ram"),
+            data.get("disk"),
+            data.get("ssh_key"),
+            data.get("contextualization", False),
+            data.get("extra", {}),
         )
         # Return VM object (with state) for polling
-        return Response(OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED)
+        return Response(
+            OpenNebulaVirtualMachineSerializer(vm).data, status=status.HTTP_201_CREATED
+        )
+
 
 @extend_schema(
     request=OpenNebulaVMMigrateSerializer,
-    responses={202: OpenApiResponse(description='Migration scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Migrate a VM to a target host/datastore."
+    responses={
+        202: OpenApiResponse(description="Migration scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Migrate a VM to a target host/datastore.",
 )
 class OpenNebulaVMMigrateView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMMigrateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         migrate_vm_task(
             vm.pk,
-            data['host_id'],
-            data.get('live', True),
-            data.get('enforce', False),
-            data.get('ds_id'),
-            data.get('migration_type', 0),
+            data["host_id"],
+            data.get("live", True),
+            data.get("enforce", False),
+            data.get("ds_id"),
+            data.get("migration_type", 0),
         )
-        return Response({'detail': 'Migration scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Migration scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskAttachSerializer,
-    responses={202: OpenApiResponse(description='Disk attach scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Attach a disk/image to a VM."
+    responses={
+        202: OpenApiResponse(description="Disk attach scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Attach a disk/image to a VM.",
 )
 class OpenNebulaDiskAttachView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskAttachSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         disk_template = {
-            'IMAGE_ID': data['image_id'],
+            "IMAGE_ID": data["image_id"],
         }
-        if data.get('size'):
-            disk_template['SIZE'] = data['size']
-        if data.get('type'):
-            disk_template['TYPE'] = data['type']
-        if data.get('target'):
-            disk_template['TARGET'] = data['target']
+        if data.get("size"):
+            disk_template["SIZE"] = data["size"]
+        if data.get("type"):
+            disk_template["TYPE"] = data["type"]
+        if data.get("target"):
+            disk_template["TARGET"] = data["target"]
         attach_disk_task(vm.pk, disk_template)
-        return Response({'detail': 'Disk attach scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Disk attach scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskResizeSerializer,
-    responses={202: OpenApiResponse(description='Disk resize scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Resize a disk attached to a VM."
+    responses={
+        202: OpenApiResponse(description="Disk resize scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Resize a disk attached to a VM.",
 )
 class OpenNebulaDiskResizeView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskResizeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
-        resize_disk_task(vm.pk, data['disk_id'], data['size'])
-        return Response({'detail': 'Disk resize scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        vm = data["vm"]
+        resize_disk_task(vm.pk, data["disk_id"], data["size"])
+        return Response(
+            {"detail": "Disk resize scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaDiskSaveAsSerializer,
-    responses={202: OpenApiResponse(description='Save disk as image scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Save a disk as a new image."
+    responses={
+        202: OpenApiResponse(description="Save disk as image scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Save a disk as a new image.",
 )
 class OpenNebulaDiskSaveAsView(APIView):
     def post(self, request):
         serializer = OpenNebulaDiskSaveAsSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         save_disk_as_image_task(
             vm.pk,
-            data['disk_id'],
-            data['image_name'],
-            data.get('image_type', ''),
-            data.get('snapshot_id', -1),
+            data["disk_id"],
+            data["image_name"],
+            data.get("image_type", ""),
+            data.get("snapshot_id", -1),
         )
-        return Response({'detail': 'Save as image scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Save as image scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaVMSnapshotSerializer,
-    responses={202: OpenApiResponse(description='Snapshot creation scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a snapshot for a VM."
+    responses={
+        202: OpenApiResponse(description="Snapshot creation scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a snapshot for a VM.",
 )
 class OpenNebulaVMSnapshotView(APIView):
     def post(self, request):
         serializer = OpenNebulaVMSnapshotSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_vm_snapshot_task(data['vm'].pk, data['name'])
-        return Response({'detail': 'Snapshot creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_vm_snapshot_task(data["vm"].pk, data["name"])
+        return Response(
+            {"detail": "Snapshot creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaVMListSnapshotsSerializer,
-    responses={200: OpenApiResponse(description='List of VM snapshots'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="List all snapshots for a VM."
+    responses={
+        200: OpenApiResponse(description="List of VM snapshots"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List all snapshots for a VM.",
 )
 class OpenNebulaVMListSnapshotsView(APIView):
     def get(self, request):
         serializer = OpenNebulaVMListSnapshotsSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         # Assume backend.list_snapshots(vm) returns a list of dicts
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             snapshots = backend.list_snapshots(vm)
             return Response(snapshots, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     request=OpenNebulaBackupCreateSerializer,
-    responses={202: OpenApiResponse(description='Backup creation scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Create a backup for a VM."
+    responses={
+        202: OpenApiResponse(description="Backup creation scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Create a backup for a VM.",
 )
 class OpenNebulaBackupCreateView(APIView):
     def post(self, request):
         serializer = OpenNebulaBackupCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        create_backup_task(data['vm'].pk, data['name'], data.get('description', ''))
-        return Response({'detail': 'Backup creation scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        create_backup_task(data["vm"].pk, data["name"], data.get("description", ""))
+        return Response(
+            {"detail": "Backup creation scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
     request=OpenNebulaBackupListSerializer,
-    responses={200: OpenApiResponse(description='List of VM backups'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="List all backups for a VM."
+    responses={
+        200: OpenApiResponse(description="List of VM backups"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List all backups for a VM.",
 )
 class OpenNebulaBackupListView(APIView):
     def get(self, request):
         serializer = OpenNebulaBackupListSerializer(data=request.query_params)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
-        vm = data['vm']
+        vm = data["vm"]
         try:
             backend = OpenNebulaBackend(vm.service_settings)
             backups = backend.list_backups(vm)
             return Response(backups, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     request=OpenNebulaRestoreBackupSerializer,
-    responses={202: OpenApiResponse(description='Backup restore scheduled'), 400: OpenApiResponse(description='Validation error'), 500: OpenApiResponse(description='Backend error')},
-    description="Restore a backup to a VM or as a new VM."
+    responses={
+        202: OpenApiResponse(description="Backup restore scheduled"),
+        400: OpenApiResponse(description="Validation error"),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="Restore a backup to a VM or as a new VM.",
 )
 class OpenNebulaRestoreBackupView(APIView):
     def post(self, request):
@@ -1105,34 +1554,47 @@ class OpenNebulaRestoreBackupView(APIView):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
         restore_backup_task(
-            data['backup_id'],
-            data.get('vm').pk if data.get('vm') else None,
-            data.get('in_place', True),
-            data.get('new_vm_name', ''),
+            data["backup_id"],
+            data.get("vm").pk if data.get("vm") else None,
+            data.get("in_place", True),
+            data.get("new_vm_name", ""),
         )
-        return Response({'detail': 'Backup restore scheduled.'}, status=status.HTTP_202_ACCEPTED)
+        return Response(
+            {"detail": "Backup restore scheduled."}, status=status.HTTP_202_ACCEPTED
+        )
+
 
 @extend_schema(
-    responses={200: OpenApiResponse(OpenNebulaMarketplaceOfferingSerializer(many=True)), 500: OpenApiResponse(description='Backend error')},
-    description="List available marketplace offerings (templates/images)."
+    responses={
+        200: OpenApiResponse(OpenNebulaMarketplaceOfferingSerializer(many=True)),
+        500: OpenApiResponse(description="Backend error"),
+    },
+    description="List available marketplace offerings (templates/images).",
 )
 class OpenNebulaMarketplaceOfferingListView(APIView):
     def get(self, request):
         try:
             # Use the first available service_settings for demonstration; in production, filter by user/project
             from waldur_core.structure.models import ServiceSettings
-            settings = ServiceSettings.objects.filter(type='OpenNebula').first()
+
+            settings = ServiceSettings.objects.filter(type="OpenNebula").first()
             if not settings:
-                return Response({'detail': 'No OpenNebula service settings found.'}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"detail": "No OpenNebula service settings found."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
             backend = OpenNebulaBackend(settings)
             offerings = backend.list_marketplace_offerings()
             return Response(offerings, status=status.HTTP_200_OK)
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer)},
-    description="Get monitoring data for a VM."
+    description="Get monitoring data for a VM.",
 )
 class OpenNebulaVMMonitoringView(APIView):
     def get(self, request, pk):
@@ -1141,20 +1603,24 @@ class OpenNebulaVMMonitoringView(APIView):
         data = backend.get_vm_monitoring(vm)
         return Response(data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaVMMonitoringSerializer(many=True))},
-    description="Get monitoring data for all VMs."
+    description="Get monitoring data for all VMs.",
 )
 class OpenNebulaVMPoolMonitoringView(APIView):
     def get(self, request):
         # Optionally filter by user/project
-        backend = OpenNebulaBackend(ServiceSettings.objects.filter(type='OpenNebula').first())
+        backend = OpenNebulaBackend(
+            ServiceSettings.objects.filter(type="OpenNebula").first()
+        )
         data = backend.get_vmpool_monitoring()
         return Response(data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     responses={200: OpenApiResponse(OpenNebulaQuotaSerializer)},
-    description="Get quota/usage for a tenant."
+    description="Get quota/usage for a tenant.",
 )
 class OpenNebulaQuotaView(APIView):
     def get(self, request, tenant_pk):
@@ -1163,6 +1629,7 @@ class OpenNebulaQuotaView(APIView):
         data = backend.get_group_quota(tenant)
         return Response(data, status=status.HTTP_200_OK)
 
+
 class OpenNebulaScheduledActionViewSet(viewsets.ModelViewSet):
     queryset = OpenNebulaScheduledAction.objects.all()
     serializer_class = OpenNebulaScheduledActionSerializer
@@ -1170,122 +1637,199 @@ class OpenNebulaScheduledActionViewSet(viewsets.ModelViewSet):
 
 class OpenNebulaTemplatesViewSet(viewsets.ViewSet):
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of VM templates')},
-        description="List available VM templates for deployment."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of VM templates")},
+        description="List available VM templates for deployment.",
     )
     def list(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(
+                settings.backend_url, settings.username, settings.password
+            )
             templates = client.list_templates()
             # Minimal serialization for wizard
             data = [
-                {'id': t.ID, 'name': t.NAME, 'cpu': getattr(t.TEMPLATE, 'CPU', None), 'memory': getattr(t.TEMPLATE, 'MEMORY', None)}
-                for t in getattr(templates, 'VMTEMPLATE', [])
+                {
+                    "id": t.ID,
+                    "name": t.NAME,
+                    "cpu": getattr(t.TEMPLATE, "CPU", None),
+                    "memory": getattr(t.TEMPLATE, "MEMORY", None),
+                }
+                for t in getattr(templates, "VMTEMPLATE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         parameters=[
-            OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY),
-            OpenApiParameter('id', type=int, required=True, location=OpenApiParameter.PATH)
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                "id", type=int, required=True, location=OpenApiParameter.PATH
+            ),
         ],
-        responses={200: OpenApiResponse(description='Template details')},
-        description="Get details of a specific VM template."
+        responses={200: OpenApiResponse(description="Template details")},
+        description="Get details of a specific VM template.",
     )
     def retrieve(self, request, pk=None):  # TODO: Implentation
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
-            settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
-            #template = client.get_template(pk) - TODO GET TEMPLATE
-            template = "";
+            ServiceSettings.objects.get(pk=service_settings_id)
+            # template = client.get_template(pk) - TODO GET TEMPLATE
+            template = ""
             if not template:
-                return Response({'detail': 'Template not found.'}, status=status.HTTP_404_NOT_FOUND)
-                
+                return Response(
+                    {"detail": "Template not found."}, status=status.HTTP_404_NOT_FOUND
+                )
+
             # Extract template details
             data = {
-                'id': template.ID,
-                'name': template.NAME,
-                'cpu': getattr(template.TEMPLATE, 'CPU', None),
-                'memory': getattr(template.TEMPLATE, 'MEMORY', None),
-                'disk': getattr(template.TEMPLATE, 'DISK', []),
-                'nic': getattr(template.TEMPLATE, 'NIC', []),
-                'template_data': template.TEMPLATE.toxml()
+                "id": template.ID,
+                "name": template.NAME,
+                "cpu": getattr(template.TEMPLATE, "CPU", None),
+                "memory": getattr(template.TEMPLATE, "MEMORY", None),
+                "disk": getattr(template.TEMPLATE, "DISK", []),
+                "nic": getattr(template.TEMPLATE, "NIC", []),
+                "template_data": template.TEMPLATE.toxml(),
             }
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
 
 class OpenNebulaImagesViewSet(viewsets.ViewSet):
     @extend_schema(
-        parameters=[OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY)],
-        responses={200: OpenApiResponse(description='List of images')},
-        description="List available images for disk attach or VM creation."
+        parameters=[
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            )
+        ],
+        responses={200: OpenApiResponse(description="List of images")},
+        description="List available images for disk attach or VM creation.",
     )
     def list(self, request):
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
+            client = OpenNebulaClient(
+                settings.backend_url, settings.username, settings.password
+            )
             images = client.list_images()
             data = [
-                {'id': i.ID, 'name': i.NAME, 'size': getattr(i, 'SIZE', None), 'type': getattr(i, 'TYPE', None)}
-                for i in getattr(images, 'IMAGE', [])
+                {
+                    "id": i.ID,
+                    "name": i.NAME,
+                    "size": getattr(i, "SIZE", None),
+                    "type": getattr(i, "TYPE", None),
+                }
+                for i in getattr(images, "IMAGE", [])
             ]
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-    
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     @extend_schema(
         parameters=[
-            OpenApiParameter('service_settings', type=int, required=True, location=OpenApiParameter.QUERY),
-            OpenApiParameter('id', type=int, required=True, location=OpenApiParameter.PATH)
+            OpenApiParameter(
+                "service_settings",
+                type=int,
+                required=True,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                "id", type=int, required=True, location=OpenApiParameter.PATH
+            ),
         ],
-        responses={200: OpenApiResponse(description='Image details')},
-        description="Get details of a specific image."
+        responses={200: OpenApiResponse(description="Image details")},
+        description="Get details of a specific image.",
     )
     def retrieve(self, request, pk=None):  # TODO: Implentation
-        service_settings_id = request.query_params.get('service_settings')
+        service_settings_id = request.query_params.get("service_settings")
         if not service_settings_id:
-            return Response({'detail': 'service_settings is required.'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "service_settings is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
-            settings = ServiceSettings.objects.get(pk=service_settings_id)
-            client = OpenNebulaClient(settings.backend_url, settings.username, settings.password)
-            #image = client.get_image(pk)
-            image = "";
+            ServiceSettings.objects.get(pk=service_settings_id)
+            # image = client.get_image(pk)
+            image = ""
             if not image:
-                return Response({'detail': 'Image not found.'}, status=status.HTTP_404_NOT_FOUND)
-                
+                return Response(
+                    {"detail": "Image not found."}, status=status.HTTP_404_NOT_FOUND
+                )
+
             # Extract image details
             data = {
-                'id': image.ID,
-                'name': image.NAME,
-                'size': getattr(image, 'SIZE', None),
-                'type': getattr(image, 'TYPE', None),
-                'persistent': getattr(image, 'PERSISTENT', None),
-                'format': getattr(image, 'FORMAT', None),
-                'state': getattr(image, 'STATE', None),
-                'image_data': image.toxml()
+                "id": image.ID,
+                "name": image.NAME,
+                "size": getattr(image, "SIZE", None),
+                "type": getattr(image, "TYPE", None),
+                "persistent": getattr(image, "PERSISTENT", None),
+                "format": getattr(image, "FORMAT", None),
+                "state": getattr(image, "STATE", None),
+                "image_data": image.toxml(),
             }
             return Response(data)
         except ServiceSettings.DoesNotExist:
-            return Response({'detail': 'ServiceSettings not found.'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"detail": "ServiceSettings not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
         except Exception as e:
-            return Response({'detail': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
## Summary
- extend the OpenNebula tenant creation serializer to require project and service settings and validate their compatibility
- save tenants before invoking the backend so creation uses the selected settings and update backend/tasks/tests to operate on the persisted instance
- align tests and factories with the OpenNebula service type and remove unused backend/view variables flagged by linting

## Testing
- python -m pytest src/waldur_opennebula/tests/test_backend.py src/waldur_opennebula/tests/test_models.py src/waldur_opennebula/tests/test_views.py *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_b_68d21fefd7448324b6e6d905d2b296d9